### PR TITLE
월별 일기 목록 api 구현

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -1,0 +1,39 @@
+package tipitapi.drawmytoday.common.utils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class DateUtils {
+
+    public static LocalDateTime getStartDate(int year, int month) {
+        validateMonth(month);
+        return LocalDateTime.of(year, month, 1, 0, 0, 0);
+    }
+
+    public static LocalDateTime getEndDate(int year, int month) {
+        validateMonth(month);
+        return LocalDateTime.of(year, month, getMaxDay(month), 23, 59);
+    }
+
+    private static void validateMonth(int month) {
+        if (month > 12 || month < 1) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private static int getMaxDay(int month) {
+        boolean is31 = List.of(1, 3, 5, 7, 8, 10, 12).stream()
+            .anyMatch(m -> m == month);
+        boolean is30 = List.of(4, 6, 9, 11).stream()
+            .anyMatch(m -> m == month);
+        if (is31) {
+            return 31;
+        } else if (is30) {
+            return 30;
+        } else {
+            return 28;
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.common.utils;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import tipitapi.drawmytoday.common.exception.BusinessException;
@@ -27,16 +27,14 @@ public class DateUtils {
     }
 
     private static int getMaxDay(int month) {
-        boolean is31 = List.of(1, 3, 5, 7, 8, 10, 12).stream()
-            .anyMatch(m -> m == month);
-        boolean is30 = List.of(4, 6, 9, 11).stream()
-            .anyMatch(m -> m == month);
-        if (is31) {
-            return 31;
-        } else if (is30) {
-            return 30;
-        } else {
+        if (month == 2) {
             return 28;
+        }
+        if (Stream.of(1, 3, 5, 7, 8, 10, 12)
+            .anyMatch(m -> m == month)) {
+            return 31;
+        } else {
+            return 30;
         }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -2,9 +2,12 @@ package tipitapi.drawmytoday.common.utils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.exception.ErrorCode;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DateUtils {
 
     public static LocalDateTime getStartDate(int year, int month) {

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -7,16 +7,19 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
+import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.service.DiaryService;
 
@@ -48,6 +51,31 @@ public class DiaryController {
     ) {
         return SuccessResponse.of(
             diaryService.getDiary(tokenInfo.getUserId(), diaryId)
+        ).asHttp(HttpStatus.OK);
+    }
+
+    @Operation(summary = "월별 일기 목록", description = "메인 화면의 캘린더 뷰에서 사용하는, 월별 일기 목록을 반환하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "입력한 연도의 월에 해당하는 일기 목록이 없으면 배열을 반환하지 않는다."),
+        @ApiResponse(
+            responseCode = "400",
+            description = "C001 : month 값이 1~12 사이의 정수가 아닙니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "U001: 해당 토큰의 유저를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @GetMapping("/calendar/monthly")
+    public ResponseEntity<SuccessResponse<List<GetDiariesResponse>>> getDiaries(
+        @Parameter(description = "조회할 연도", in = ParameterIn.PATH) @RequestParam("year") int year,
+        @Parameter(description = "조회할 달", in = ParameterIn.PATH) @RequestParam("month") int month
+        , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        return SuccessResponse.of(
+            diaryService.getDiaries(tokenInfo.getUserId(), year, month)
         ).asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
-import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.diary.service.DiaryService;
 
 @RestController
@@ -69,13 +69,13 @@ public class DiaryController {
             content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/calendar/monthly")
-    public ResponseEntity<SuccessResponse<List<GetDiariesResponse>>> getDiaries(
+    public ResponseEntity<SuccessResponse<List<GetMonthlyDiariesResponse>>> getMonthlyDiaries(
         @Parameter(description = "조회할 연도", in = ParameterIn.PATH) @RequestParam("year") int year,
         @Parameter(description = "조회할 달", in = ParameterIn.PATH) @RequestParam("month") int month
         , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            diaryService.getDiaries(tokenInfo.getUserId(), year, month)
+            diaryService.getMonthlyDiaries(tokenInfo.getUserId(), year, month)
         ).asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -1,6 +1,8 @@
 package tipitapi.drawmytoday.diary.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -11,6 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -59,6 +62,8 @@ public class Diary extends BaseEntityWithUpdate {
     @Enumerated(EnumType.STRING)
     private ReviewType review;
 
+    @OneToMany(mappedBy = "diary")
+    private List<Image> imageList;
 
     @Builder
     public Diary(User user, Emotion emotion, LocalDateTime diaryDate, String notes, boolean isAi,
@@ -72,5 +77,6 @@ public class Diary extends BaseEntityWithUpdate {
         this.title = title;
         this.weather = weather;
         this.review = review;
+        this.imageList = new ArrayList<>();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Image.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Image.java
@@ -37,6 +37,7 @@ public class Image extends BaseEntity {
 
     private Image(Diary diary, String imageUrl, boolean isSelected) {
         this.diary = diary;
+        diary.getImageList().add(this);
         this.imageUrl = imageUrl;
         this.isSelected = isSelected;
     }

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiariesResponse.java
@@ -1,0 +1,36 @@
+package tipitapi.drawmytoday.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import tipitapi.drawmytoday.diary.domain.Diary;
+
+@Getter
+@Schema(description = "월별 일기 목록 Response")
+@AllArgsConstructor
+public class GetDiariesResponse {
+
+    @Schema(description = "일기 아이디", requiredMode = RequiredMode.REQUIRED)
+    private final Long id;
+
+    @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
+    private final String imageUrl;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
+    private final LocalDateTime date;
+
+    public static GetDiariesResponse of(Diary diary) {
+        return new GetDiariesResponse(diary.getDiaryId(), diary.getImageList().get(0).getImageUrl(),
+            diary.getDiaryDate());
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
@@ -15,7 +15,7 @@ import tipitapi.drawmytoday.diary.domain.Diary;
 @Getter
 @Schema(description = "월별 일기 목록 Response")
 @AllArgsConstructor
-public class GetDiariesResponse {
+public class GetMonthlyDiariesResponse {
 
     @Schema(description = "일기 아이디", requiredMode = RequiredMode.REQUIRED)
     private final Long id;
@@ -29,8 +29,9 @@ public class GetDiariesResponse {
     @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
     private final LocalDateTime date;
 
-    public static GetDiariesResponse of(Diary diary) {
-        return new GetDiariesResponse(diary.getDiaryId(), diary.getImageList().get(0).getImageUrl(),
+    public static GetMonthlyDiariesResponse of(Diary diary) {
+        return new GetMonthlyDiariesResponse(diary.getDiaryId(),
+            diary.getImageList().get(0).getImageUrl(),
             diary.getDiaryDate());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -1,8 +1,14 @@
 package tipitapi.drawmytoday.diary.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.diary.domain.Diary;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
+    @EntityGraph(attributePaths = {"imageList"})
+    List<Diary> findAllByUserUserIdAndDiaryDateBetween(Long userId, LocalDateTime startMonth,
+        LocalDateTime endMonth);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -12,6 +12,7 @@ import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
+import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.user.domain.User;
@@ -43,6 +44,12 @@ public class DiaryService {
         LocalDateTime endMonth = DateUtils.getEndDate(year, month);
         return diaryRepository.findAllByUserUserIdAndDiaryDateBetween(user.getUserId(),
                 startMonth, endMonth).stream()
+            .filter(diary -> {
+                if (diary.getImageList().isEmpty()) {
+                    throw new ImageNotFoundException();
+                }
+                return true;
+            })
             .map(GetDiariesResponse::of)
             .collect(Collectors.toList());
     }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
-import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
@@ -38,7 +38,7 @@ public class DiaryService {
         return GetDiaryResponse.of(diary, image, diary.getEmotion());
     }
 
-    public List<GetDiariesResponse> getDiaries(Long userId, int year, int month) {
+    public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, int year, int month) {
         User user = validateUserService.validateUserById(userId);
         LocalDateTime startMonth = DateUtils.getStartDate(year, month);
         LocalDateTime endMonth = DateUtils.getEndDate(year, month);
@@ -50,7 +50,7 @@ public class DiaryService {
                 }
                 return true;
             })
-            .map(GetDiariesResponse::of)
+            .map(GetMonthlyDiariesResponse::of)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -42,8 +42,13 @@ public class DiaryService {
         User user = validateUserService.validateUserById(userId);
         LocalDateTime startMonth = DateUtils.getStartDate(year, month);
         LocalDateTime endMonth = DateUtils.getEndDate(year, month);
-        return diaryRepository.findAllByUserUserIdAndDiaryDateBetween(user.getUserId(),
-                startMonth, endMonth).stream()
+        List<Diary> getDiaryList = diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
+            user.getUserId(), startMonth, endMonth);
+        return convertDiariesToResponse(getDiaryList);
+    }
+
+    private List<GetMonthlyDiariesResponse> convertDiariesToResponse(List<Diary> getDiaryList) {
+        return getDiaryList.stream()
             .filter(diary -> {
                 if (diary.getImageList().isEmpty()) {
                     throw new ImageNotFoundException();

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -1,10 +1,15 @@
 package tipitapi.drawmytoday.diary.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
+import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
@@ -28,8 +33,18 @@ public class DiaryService {
             .orElseThrow(DiaryNotFoundException::new);
         ownedByUser(diary, user);
         Image image = imageService.getImage(diary);
-        
+
         return GetDiaryResponse.of(diary, image, diary.getEmotion());
+    }
+
+    public List<GetDiariesResponse> getDiaries(Long userId, int year, int month) {
+        User user = validateUserService.validateUserById(userId);
+        LocalDateTime startMonth = DateUtils.getStartDate(year, month);
+        LocalDateTime endMonth = DateUtils.getEndDate(year, month);
+        return diaryRepository.findAllByUserUserIdAndDiaryDateBetween(user.getUserId(),
+                startMonth, endMonth).stream()
+            .map(GetDiariesResponse::of)
+            .collect(Collectors.toList());
     }
 
     private void ownedByUser(Diary diary, User user) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -18,4 +18,12 @@ public class TestDiary {
         ReflectionTestUtils.setField(diary, "diaryId", diaryId);
         return diary;
     }
+
+    public static Diary createDiaryWithIdAndDate(Long diaryId, LocalDateTime diaryDate, User user,
+        Emotion emotion) {
+        Diary diary = createDiary(user, emotion);
+        ReflectionTestUtils.setField(diary, "diaryId", diaryId);
+        ReflectionTestUtils.setField(diary, "diaryDate", diaryDate);
+        return diary;
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.common.testdata;
 
+import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 public class TestEmotion {
@@ -7,5 +8,11 @@ public class TestEmotion {
     public static Emotion createEmotion() {
         return Emotion.create("HAPPY", "#12312", true, "example emotion prompt",
             "example color prompt");
+    }
+
+    public static Emotion createEmotionWithId(Long emotionId) {
+        Emotion emotion = createEmotion();
+        ReflectionTestUtils.setField(emotion, "emotionId", emotionId);
+        return emotion;
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -1,7 +1,12 @@
 package tipitapi.drawmytoday.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithIdAndDate;
+import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotionWithId;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,7 +16,9 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import tipitapi.drawmytoday.common.BaseRepositoryTest;
+import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.user.domain.User;
 
 @DataJpaTest
@@ -52,6 +59,82 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                 Optional<Diary> foundDiary = diaryRepository.findById(1L);
 
                 assertThat(foundDiary).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByUserUserIdAndDiaryDateBetween 메소드 테스트")
+    class findAllByUserUserIdAndDiaryDateBetweenTest {
+
+        private final LocalDateTime START_DATE = DateUtils.getStartDate(2023, 6);
+        private final LocalDateTime END_DATE = DateUtils.getStartDate(2023, 6);
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 없을 경우")
+        class if_user_not_exist {
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다.")
+            void return_empty_list() {
+                Long existUserId = 1L;
+                Long inputUserId = 2L;
+                createUserWithId(existUserId);
+
+                assertThat(
+                    diaryRepository.findAllByUserUserIdAndDiaryDateBetween(inputUserId, START_DATE,
+                        END_DATE))
+                    .isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 있으나 월에 해당하는 일기가 없을 경우")
+        class if_user_exist_but_diary_not_exist {
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다.")
+            void return_empty_list() {
+                LocalDateTime diaryDate = LocalDateTime.of(2023, 5, 1, 0, 0);
+                Long userId = 1L;
+                User user = createUserWithId(userId);
+                Emotion emotion = createEmotionWithId(1L);
+                Diary diary = createDiaryWithIdAndDate(1L, diaryDate, user, emotion);
+                userRepository.save(user);
+                emotionRepository.save(emotion);
+                diaryRepository.save(diary);
+                createImage(1L, diary);
+
+                assertThat(
+                    diaryRepository.findAllByUserUserIdAndDiaryDateBetween(userId, START_DATE,
+                        END_DATE))
+                    .isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 있고 월에 해당하는 일기가 있을 경우")
+        class if_user_exist_and_diary_exist {
+
+            @Test
+            @DisplayName("해당 월의 일기 리스트를 반환한다.")
+            void return_diary_list() {
+                LocalDateTime diaryDate = LocalDateTime.of(2023, 6, 1, 0, 0);
+                Long userId = 1L;
+                User user = createUserWithId(userId);
+                Emotion emotion = createEmotionWithId(1L);
+                Diary diary1 = createDiaryWithIdAndDate(1L, diaryDate, user, emotion);
+                Diary diary2 = createDiaryWithIdAndDate(2L, diaryDate, user, emotion);
+                userRepository.save(user);
+                emotionRepository.save(emotion);
+                diaryRepository.save(diary1);
+                diaryRepository.save(diary2);
+                createImage(1L, diary1);
+                createImage(2L, diary2);
+
+                List<Diary> diaryList = diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
+                    userId, START_DATE, END_DATE);
+                assertThat(diaryList.size()).isEqualTo(2);
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.diary.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
@@ -9,21 +10,28 @@ import static tipitapi.drawmytoday.common.testdata.TestImage.createImage;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
+import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,6 +102,74 @@ class DiaryServiceTest {
 
                 assertThatThrownBy(() -> diaryService.getDiary(1L, 1L))
                     .isInstanceOf(NotOwnerOfDiaryException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getDiaries 메소드 테스트")
+    class GetDiariesTest {
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
+        class if_user_not_exists {
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 발생시킨다.")
+            void it_throws_UserNotFoundException() {
+                given(validateUserService.validateUserById(1L)).willThrow(
+                    new UserNotFoundException());
+
+                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, 6))
+                    .isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("month 값이")
+        class if_month_value {
+
+            @ParameterizedTest
+            @DisplayName("1보다 작을 경우 BusinessException 예외를 발생시킨다.")
+            @ValueSource(ints = {0, -1})
+            void less_1_then_throws_BusinessException(int value) {
+                User user = createUser();
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+
+                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, value))
+                    .isInstanceOf(BusinessException.class);
+            }
+
+            @ParameterizedTest
+            @DisplayName("12보다 클 경우 BusinessException 예외를 발생시킨다.")
+            @ValueSource(ints = {13, 14, 999})
+            void more_12_then_throws_BusinessException(int value) {
+                User user = createUser();
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+
+                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, value))
+                    .isInstanceOf(BusinessException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 유저의 일기가 존재할 경우")
+        class if_diary_of_user_exists {
+
+            @Test
+            @DisplayName("일기들을 반환한다.")
+            void it_returns_diaries() {
+                User user = createUserWithId(1L);
+                Diary diary = createDiaryWithId(1L, user, createEmotion());
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
+                    any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                    .willReturn(List.of(diary));
+
+                List<GetDiariesResponse> getDiaryResponses = diaryService.getDiaries(1L, 2023, 6);
+
+                assertThat(getDiaryResponses).hasSize(1);
+                assertThat(getDiaryResponses.get(0).getId()).isEqualTo(diary.getDiaryId());
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -25,8 +25,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
-import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
@@ -121,7 +121,7 @@ class DiaryServiceTest {
                 given(validateUserService.validateUserById(1L)).willThrow(
                     new UserNotFoundException());
 
-                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, 6))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6))
                     .isInstanceOf(UserNotFoundException.class);
             }
         }
@@ -137,7 +137,7 @@ class DiaryServiceTest {
                 User user = createUser();
                 given(validateUserService.validateUserById(1L)).willReturn(user);
 
-                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, value))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value))
                     .isInstanceOf(BusinessException.class);
             }
 
@@ -148,7 +148,7 @@ class DiaryServiceTest {
                 User user = createUser();
                 given(validateUserService.validateUserById(1L)).willReturn(user);
 
-                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, value))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value))
                     .isInstanceOf(BusinessException.class);
             }
         }
@@ -167,7 +167,7 @@ class DiaryServiceTest {
                     any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))
                     .willReturn(List.of(diary));
 
-                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, 6))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6))
                     .isInstanceOf(ImageNotFoundException.class);
             }
 
@@ -182,7 +182,9 @@ class DiaryServiceTest {
                     any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))
                     .willReturn(List.of(diary));
 
-                List<GetDiariesResponse> getDiaryResponses = diaryService.getDiaries(1L, 2023, 6);
+                List<GetMonthlyDiariesResponse> getDiaryResponses = diaryService.getMonthlyDiaries(
+                    1L,
+                    2023, 6);
 
                 assertThat(getDiaryResponses).hasSize(1);
                 assertThat(getDiaryResponses.get(0).getId()).isEqualTo(diary.getDiaryId());

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -28,6 +28,7 @@ import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.diary.dto.GetDiariesResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
+import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.user.domain.User;
@@ -157,10 +158,25 @@ class DiaryServiceTest {
         class if_diary_of_user_exists {
 
             @Test
+            @DisplayName("일기에 해당하는 이미지가 없을 경우")
+            void it_returns_diaries_without_image() {
+                User user = createUserWithId(1L);
+                Diary diary = createDiaryWithId(1L, user, createEmotion());
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
+                    any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                    .willReturn(List.of(diary));
+
+                assertThatThrownBy(() -> diaryService.getDiaries(1L, 2023, 6))
+                    .isInstanceOf(ImageNotFoundException.class);
+            }
+
+            @Test
             @DisplayName("일기들을 반환한다.")
             void it_returns_diaries() {
                 User user = createUserWithId(1L);
                 Diary diary = createDiaryWithId(1L, user, createEmotion());
+                createImage(diary);
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
                     any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))


### PR DESCRIPTION
# 구현 내용

- 월별 일기 목록 api 구현 시
- 연도를 쿼리 파라미터로 받도록 추가했습니다.
- Diary를 가져올 때 Image들도 손쉽게 가져오기 위해 Diary와 Image를 양방향 매핑하였습니다.
- 연도와 월 값을 LocalDateTime으로 변환하는 DateUtils 클래스를 만들었습니다.
- 테스트도 구현했습니다.(나중에 Controller 단위 테스트도 추가하겠습니다)

## 관련 이슈

close #23 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
