### PR TITLE
마지막 일기 생성 시각 조회 API

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import javax.validation.Valid;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +27,7 @@ import tipitapi.drawmytoday.dalle.exception.ImageInputStreamFailException;
 import tipitapi.drawmytoday.diary.dto.CreateDiaryRequest;
 import tipitapi.drawmytoday.diary.dto.CreateDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.diary.service.CreateDiaryService;
 import tipitapi.drawmytoday.diary.service.DiaryService;
@@ -87,7 +88,30 @@ public class DiaryController {
             diaryService.getMonthlyDiaries(tokenInfo.getUserId(), year, month)
         ).asHttp(HttpStatus.OK);
     }
-  
+
+    @Operation(summary = "마지막 일기 생성 시각 조회", description = "유저가 마지막으로 일기를 생성한 시각을 반환한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "마지막 일기 생성 시각 정보"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @GetMapping("/last-creation")
+    public ResponseEntity<SuccessResponse<GetLastCreationResponse>> getLastCreation(
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        return SuccessResponse.of(
+            diaryService.getLastCreation(tokenInfo.getUserId())
+        ).asHttp(HttpStatus.OK);
+    }
+
     @Operation(summary = "일기 생성", description = "DALL-E API를 사용하여 이미지를 발급하여 일기를 생성한다.")
     @ApiResponses(value = {
         @ApiResponse(

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetLastCreationResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetLastCreationResponse.java
@@ -1,0 +1,23 @@
+package tipitapi.drawmytoday.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "마지막 일기 생성 시각 조회 Response")
+@AllArgsConstructor
+public class GetLastCreationResponse {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "마지막 일기 생성 날짜", nullable = true)
+    private LocalDateTime lastCreation;
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.diary.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.diary.domain.Diary;
@@ -11,4 +12,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @EntityGraph(attributePaths = {"imageList"})
     List<Diary> findAllByUserUserIdAndDiaryDateBetween(Long userId, LocalDateTime startMonth,
         LocalDateTime endMonth);
+
+    Optional<Diary> findFirstByUserUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -6,10 +6,12 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.common.entity.BaseEntity;
 import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
@@ -45,6 +47,14 @@ public class DiaryService {
         List<Diary> getDiaryList = diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
             user.getUserId(), startMonth, endMonth);
         return convertDiariesToResponse(getDiaryList);
+    }
+
+    public GetLastCreationResponse getLastCreation(Long userId) {
+        validateUserService.validateUserById(userId);
+        return new GetLastCreationResponse(
+            diaryRepository.findFirstByUserUserIdOrderByCreatedAtDesc(userId)
+                .map(BaseEntity::getCreatedAt)
+                .orElse(null));
     }
 
     private List<GetMonthlyDiariesResponse> convertDiariesToResponse(List<Diary> getDiaryList) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -26,4 +26,13 @@ public class TestDiary {
         ReflectionTestUtils.setField(diary, "diaryDate", diaryDate);
         return diary;
     }
+
+    public static Diary createDiaryWithIdAndCreatedAt(Long diaryId, LocalDateTime createdAt,
+        User user,
+        Emotion emotion) {
+        Diary diary = createDiary(user, emotion);
+        ReflectionTestUtils.setField(diary, "diaryId", diaryId);
+        ReflectionTestUtils.setField(diary, "createdAt", createdAt);
+        return diary;
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -1,6 +1,7 @@
 package tipitapi.drawmytoday.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithIdAndCreatedAt;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithIdAndDate;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotionWithId;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
@@ -173,9 +174,9 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                 userRepository.save(user);
                 emotionRepository.save(emotion);
                 diaryRepository.saveAll(Arrays.asList(
-                    createDiaryWithIdAndDate(diaryId1, LocalDateTime.now().minusDays(2), user,
+                    createDiaryWithIdAndCreatedAt(diaryId1, LocalDateTime.now().minusDays(2), user,
                         emotion),
-                    createDiaryWithIdAndDate(diaryId2, LocalDateTime.now().minusDays(1), user,
+                    createDiaryWithIdAndCreatedAt(diaryId2, LocalDateTime.now().minusDays(1), user,
                         emotion)
                 ));
 

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -6,6 +6,7 @@ import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotionWith
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -138,4 +139,54 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("findFirstByUserUserIdOrderByCreatedAtDesc 메소드 테스트")
+    class findFirstByUserUserIdOrderByCreatedAtDescTest {
+
+        @Nested
+        @DisplayName("주어진 user의 Diary가 존재하지 않을 경우")
+        class if_diary_not_exist {
+
+            @Test
+            @DisplayName("null를 반환한다.")
+            void return_null() {
+                Long userId = 1L;
+                createUserWithId(userId);
+
+                assertThat(
+                    diaryRepository.findFirstByUserUserIdOrderByCreatedAtDesc(userId))
+                    .isNotPresent();
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 user의 Diary가 존재할 경우")
+        class if_diary_exist {
+
+            @Test
+            @DisplayName("마지막으로 생성한 Diary를 반환한다.")
+            void return_diary() {
+                Long userId = 1L, diaryId1 = 1L, diaryId2 = 2L;
+                User user = createUserWithId(userId);
+                Emotion emotion = createEmotionWithId(1L);
+                userRepository.save(user);
+                emotionRepository.save(emotion);
+                diaryRepository.saveAll(Arrays.asList(
+                    createDiaryWithIdAndDate(diaryId1, LocalDateTime.now().minusDays(2), user,
+                        emotion),
+                    createDiaryWithIdAndDate(diaryId2, LocalDateTime.now().minusDays(1), user,
+                        emotion)
+                ));
+
+                Optional<Diary> diary = diaryRepository.findFirstByUserUserIdOrderByCreatedAtDesc(
+                    userId);
+
+                assertThat(diary.isPresent()).isTrue();
+                assertThat(diary.get().getDiaryId()).isEqualTo(diaryId2);
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [GET] /diary/last-creation : 마지막 일기 생성 시각 조회 API 추가
- Repository Test 추가
- Service Test 추가
- Diary ID, 생성 시각, 감정, User ID를 파라미터로 Test Diary를 생성하는 메소드 추가


## 관련 이슈

close #27 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
