### PR TITLE
:sparkles: feature: 일기 수정 API 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,6 +30,7 @@ import tipitapi.drawmytoday.diary.dto.CreateDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
+import tipitapi.drawmytoday.diary.dto.UpdateDiaryRequest;
 import tipitapi.drawmytoday.diary.service.CreateDiaryService;
 import tipitapi.drawmytoday.diary.service.DiaryService;
 
@@ -139,5 +141,30 @@ public class DiaryController {
             createDiaryService.createDiary(tokenInfo.getUserId(), createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes())
         ).asHttp(HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "일기 수정", description = "주어진 일기의 내용을 수정한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 일기 내용을 수정함"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateDiaryNotes(
+        @RequestBody @Valid UpdateDiaryRequest updateDiaryRequest,
+        @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId,
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        diaryService.updateDiaryNotes(tokenInfo.getUserId(), diaryId,
+            updateDiaryRequest.getNotes());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -79,4 +79,8 @@ public class Diary extends BaseEntityWithUpdate {
         this.review = review;
         this.imageList = new ArrayList<>();
     }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/UpdateDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/UpdateDiaryRequest.java
@@ -1,0 +1,17 @@
+package tipitapi.drawmytoday.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Schema(description = "일기 수정 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateDiaryRequest {
+
+    @Size(max = 6010)
+    @Schema(description = "일기 내용. null로 요청할 경우, 일기의 내용을 null로 변경한다.", nullable = true)
+    private String notes;
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -57,6 +57,16 @@ public class DiaryService {
                 .orElse(null));
     }
 
+    @Transactional
+    public void updateDiaryNotes(Long userId, Long diaryId, String notes) {
+        User user = validateUserService.validateUserById(userId);
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(DiaryNotFoundException::new);
+        ownedByUser(diary, user);
+
+        diary.setNotes(notes);
+    }
+
     private List<GetMonthlyDiariesResponse> convertDiariesToResponse(List<Diary> getDiaryList) {
         return getDiaryList.stream()
             .filter(diary -> {

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -254,4 +254,85 @@ class DiaryServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("updateDiaryNotes 메소드 테스트")
+    class UpdateDiaryNotesTest {
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
+        class if_user_not_exists {
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 발생시킨다.")
+            void it_throws_UserNotFoundException() {
+                given(validateUserService.validateUserById(1L)).willThrow(
+                    new UserNotFoundException());
+
+                assertThatThrownBy(() -> diaryService.updateDiaryNotes(1L, 1L, "notes"))
+                    .isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("diaryId에 해당하는 일기가 존재하지 않을 경우")
+        class if_diary_not_exists {
+
+            @Test
+            @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
+            void it_throws_DiaryNotFoundException() {
+                User user = createUserWithId(1L);
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(diaryRepository.findById(any(Long.class)))
+                    .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> diaryService.updateDiaryNotes(1L, 1L, "notes"))
+                    .isInstanceOf(DiaryNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("일기가 존재할 경우")
+        class if_diary_exists {
+
+            @Nested
+            @DisplayName("요청한 내용이 null일 경우")
+            class if_new_notes_is_null {
+
+                @Test
+                @DisplayName("일기의 내용을 제거해 null로 만든다.")
+                void it_removes_diary_notes() {
+                    User user = createUserWithId(1L);
+                    Diary diary = createDiaryWithId(1L, user, createEmotion());
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(diaryRepository.findById(any(Long.class)))
+                        .willReturn(Optional.of(diary));
+
+                    diaryService.updateDiaryNotes(1L, 1L, null);
+
+                    assertThat(diary.getNotes()).isNull();
+                }
+            }
+
+            @Nested
+            @DisplayName("요청한 내용이 null이 아닐 경우")
+            class if_new_notes_is_not_null {
+
+                @Test
+                @DisplayName("일기의 내용을 주어진 내용으로 수정한다.")
+                void it_updates_diary_notes() {
+                    User user = createUserWithId(1L);
+                    Diary diary = createDiaryWithId(1L, user, createEmotion());
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(diaryRepository.findById(any(Long.class)))
+                        .willReturn(Optional.of(diary));
+
+                    diaryService.updateDiaryNotes(1L, 1L, "notes");
+
+                    assertThat(diary.getNotes()).isEqualTo("notes");
+                }
+            }
+
+        }
+
+    }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[PUT] /diary/:id : 일기 수정 API
- 일기 내용(notes) 수정
- null 값으로 요청할 경우, 내용이 삭제됨
- Service Test 추가

## 관련 이슈

close #29 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
