### PR TITLE
감정 목록 조회 API, 감정 등록 API 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -94,14 +94,6 @@ public class DiaryController {
         @ApiResponse(
             responseCode = "200",
             description = "마지막 일기 생성 시각 정보"),
-        @ApiResponse(
-            responseCode = "403",
-            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
-            content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(
-            responseCode = "404",
-            description = "D001 : 일기를 찾을 수 없습니다.",
-            content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/last-creation")
     public ResponseEntity<SuccessResponse<GetLastCreationResponse>> getLastCreation(

--- a/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
@@ -43,4 +43,19 @@ public class EmotionController {
             emotionService.getActiveEmotions(tokenInfo.getUserId())
         ).asHttp(HttpStatus.OK);
     }
+
+    @Operation(summary = "감정 등록", description = "주어진 감정 데이터 목록을 등록한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 감정을 등록함"),
+    })
+    @PostMapping()
+    public ResponseEntity<SuccessResponse<List<CreateEmotionResponse>>> createEmotions(
+        @RequestBody @Valid List<@Valid CreateEmotionRequest> createEmotionRequests
+    ) {
+        return SuccessResponse.of(
+            emotionService.createEmotions(createEmotionRequests)
+        ).asHttp(HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
@@ -1,0 +1,46 @@
+package tipitapi.drawmytoday.emotion.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.resolver.AuthUser;
+import tipitapi.drawmytoday.common.response.SuccessResponse;
+import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionRequest;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionResponse;
+import tipitapi.drawmytoday.emotion.dto.GetActiveEmotionsResponse;
+import tipitapi.drawmytoday.emotion.service.EmotionService;
+
+@RestController
+@RequestMapping("/emotions")
+@RequiredArgsConstructor
+public class EmotionController {
+
+    private final EmotionService emotionService;
+
+    @Operation(summary = "감정 목록 조회", description = "일기 생성시 노출할 감정의 목록을 반환한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "감정 목록 정보"),
+    })
+    @GetMapping("/all")
+    public ResponseEntity<SuccessResponse<List<GetActiveEmotionsResponse>>> getAllEmotions(
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        return SuccessResponse.of(
+            emotionService.getActiveEmotions(tokenInfo.getUserId())
+        ).asHttp(HttpStatus.OK);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionRequest.java
@@ -1,0 +1,34 @@
+package tipitapi.drawmytoday.emotion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+
+@Getter
+@Schema(description = "감정 등록 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateEmotionRequest {
+
+    @NotBlank
+    @Schema(description = "감정 이름(한국어)")
+    private String emotionName;
+
+    @NotBlank
+    @Schema(description = "감정 프롬프트 값")
+    private String emotionPrompt;
+
+    @NotBlank
+    @Schema(description = "감정 색상 HEX 코드")
+    private String colorHex;
+
+    @NotBlank
+    @Schema(description = "감정 색상 프롬프트 값")
+    private String colorPrompt;
+
+    public Emotion toEmotionEntity() {
+        return Emotion.create(emotionName, colorHex, true, emotionPrompt, colorPrompt);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionRequest.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.emotion.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
@@ -10,6 +11,7 @@ import tipitapi.drawmytoday.emotion.domain.Emotion;
 @Getter
 @Schema(description = "감정 등록 Request")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateEmotionRequest {
 
     @NotBlank

--- a/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/dto/CreateEmotionResponse.java
@@ -1,0 +1,23 @@
+package tipitapi.drawmytoday.emotion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+
+@Getter
+@Schema(description = "감정 생성 Response")
+@AllArgsConstructor
+public class CreateEmotionResponse {
+
+    @Schema(description = "추가된 감정 ID", requiredMode = RequiredMode.REQUIRED)
+    private final Long id;
+
+    @Schema(description = "추가된 감정 이름", requiredMode = RequiredMode.REQUIRED)
+    private final String emotionName;
+
+    public static CreateEmotionResponse of(Emotion emotion) {
+        return new CreateEmotionResponse(emotion.getEmotionId(), emotion.getName());
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/emotion/dto/GetActiveEmotionsResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/dto/GetActiveEmotionsResponse.java
@@ -1,0 +1,35 @@
+package tipitapi.drawmytoday.emotion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+
+@Getter
+@Schema(description = "감정 목록 조회 Response. 활성화되어 일기 생성시 옵션으로 제공할 감정의 목록이다.")
+@AllArgsConstructor
+public class GetActiveEmotionsResponse {
+
+    @Schema(description = "감정 ID", requiredMode = RequiredMode.REQUIRED)
+    private final Long id;
+
+    @Schema(description = "감정 이름", requiredMode = RequiredMode.REQUIRED)
+    private final String name;
+
+    @Schema(description = "감정 색깔 HEX", requiredMode = RequiredMode.REQUIRED)
+    private final String color;
+
+    public static GetActiveEmotionsResponse of(Long id, String name, String color) {
+        return new GetActiveEmotionsResponse(id, name, color);
+    }
+
+    public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions) {
+        return emotions.stream()
+            .map(e -> GetActiveEmotionsResponse.of(e.getEmotionId(), e.getName(), e.getColor()))
+            .collect(
+                Collectors.toList());
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/emotion/repository/EmotionRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/repository/EmotionRepository.java
@@ -1,8 +1,12 @@
 package tipitapi.drawmytoday.emotion.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {
 
+    @Query("select e from Emotion e where e.isActive = true order by e.emotionId asc")
+    List<Emotion> findAllActiveEmotions();
 }

--- a/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
@@ -25,4 +25,12 @@ public class EmotionService {
         return GetActiveEmotionsResponse.buildWithEmotions(
             emotionRepository.findAllActiveEmotions());
     }
+
+    public List<CreateEmotionResponse> createEmotions(
+        List<CreateEmotionRequest> createEmotionRequests) {
+        return emotionRepository.saveAll(
+            createEmotionRequests.stream().map(CreateEmotionRequest::toEmotionEntity).collect(
+                Collectors.toList())
+        ).stream().map(CreateEmotionResponse::of).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
@@ -1,0 +1,28 @@
+package tipitapi.drawmytoday.emotion.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionRequest;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionResponse;
+import tipitapi.drawmytoday.emotion.dto.GetActiveEmotionsResponse;
+import tipitapi.drawmytoday.emotion.repository.EmotionRepository;
+import tipitapi.drawmytoday.user.service.ValidateUserService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmotionService {
+
+    private final EmotionRepository emotionRepository;
+    private final ValidateUserService validateUserService;
+
+
+    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId) {
+        validateUserService.validateUserById(userId);
+        return GetActiveEmotionsResponse.buildWithEmotions(
+            emotionRepository.findAllActiveEmotions());
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
@@ -6,8 +6,7 @@ import tipitapi.drawmytoday.emotion.domain.Emotion;
 public class TestEmotion {
 
     public static Emotion createEmotion() {
-        return Emotion.create("HAPPY", "#12312", true, "example emotion prompt",
-            "example color prompt");
+        return Emotion.create("행복", "#FF0000", true, "happy", "red");
     }
 
     public static Emotion createEmotionWithId(Long emotionId) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestEmotion.java
@@ -15,4 +15,9 @@ public class TestEmotion {
         ReflectionTestUtils.setField(emotion, "emotionId", emotionId);
         return emotion;
     }
+
+    public static Emotion createEmotionInActive() {
+        return Emotion.create("SAD", "#45645", false, "example emotion prompt",
+            "example color prompt");
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/EmotionRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/EmotionRepositoryTest.java
@@ -1,0 +1,59 @@
+package tipitapi.drawmytoday.diary.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import tipitapi.drawmytoday.common.BaseRepositoryTest;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+import tipitapi.drawmytoday.emotion.repository.EmotionRepository;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class EmotionRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    EmotionRepository emotionRepository;
+
+    @Nested
+    @DisplayName("findAllActiveEmotions 메소드 테스트")
+    class FindAllActiveEmotionsTest {
+
+        @Nested
+        @DisplayName("활성화된 감정이 존재하지 않을 경우")
+        class is_active_emotion_not_exists {
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다.")
+            void it_returns_empty_list() {
+                List<Emotion> foundEmotions = emotionRepository.findAllActiveEmotions();
+
+                assertThat(foundEmotions).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("활성화된 감정이 존재할 경우")
+        class if_active_emotions_exist {
+
+            @Test
+            @DisplayName("활성화된 감정 목록을 반환한다.")
+            void it_returns_emotions_list() {
+                Emotion inActiveEmotion = TestEmotion.createEmotionInActive();
+                Emotion activeEmotion = TestEmotion.createEmotion();
+                emotionRepository.saveAll(List.of(inActiveEmotion, activeEmotion));
+
+                List<Emotion> foundEmotions = emotionRepository.findAllActiveEmotions();
+                assertThat(foundEmotions).hasSize(1);
+                assertThat(foundEmotions.get(0)).isEqualTo(activeEmotion);
+            }
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
@@ -2,11 +2,14 @@ package tipitapi.drawmytoday.diary.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotionInActive;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,7 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionRequest;
+import tipitapi.drawmytoday.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.emotion.dto.GetActiveEmotionsResponse;
 import tipitapi.drawmytoday.emotion.repository.EmotionRepository;
 import tipitapi.drawmytoday.emotion.service.EmotionService;
@@ -74,6 +80,34 @@ public class EmotionServiceTest {
                     .isNotEqualTo(inActiveEmotion.getEmotionId());
             }
         }
+    }
 
+    @Nested
+    @DisplayName("createEmotions 메소드 테스트")
+    class CreateEmotionsTest {
+
+        @Test
+        @DisplayName("감정을 생성한다.")
+        void it_creates_emotions_and_returns_created_emotions()
+            throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+            Emotion emotion = TestEmotion.createEmotion();
+            CreateEmotionRequest request = buildCreateEmotionRequest(emotion.getName(),
+                emotion.getEmotionPrompt(), emotion.getColor(), emotion.getColorPrompt());
+            given(emotionRepository.saveAll(anyList())).willReturn(List.of(emotion));
+
+            List<CreateEmotionResponse> response = emotionService.createEmotions(List.of(request));
+
+            assertThat(response.get(0).getId()).isEqualTo(emotion.getEmotionId());
+        }
+
+        private CreateEmotionRequest buildCreateEmotionRequest(String emotionName,
+            String emotionPrompt,
+            String colorHex, String colorPrompt)
+            throws InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
+            Constructor<CreateEmotionRequest> constructor = CreateEmotionRequest.class.getDeclaredConstructor(
+                String.class, String.class, String.class, String.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(emotionName, emotionPrompt, colorHex, colorPrompt);
+        }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
@@ -1,0 +1,79 @@
+package tipitapi.drawmytoday.diary.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
+import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotionInActive;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+import tipitapi.drawmytoday.emotion.dto.GetActiveEmotionsResponse;
+import tipitapi.drawmytoday.emotion.repository.EmotionRepository;
+import tipitapi.drawmytoday.emotion.service.EmotionService;
+import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.exception.UserNotFoundException;
+import tipitapi.drawmytoday.user.service.ValidateUserService;
+
+@ExtendWith(MockitoExtension.class)
+public class EmotionServiceTest {
+
+    @Mock
+    EmotionRepository emotionRepository;
+
+    @Mock
+    ValidateUserService validateUserService;
+
+    @InjectMocks
+    EmotionService emotionService;
+
+    @Nested
+    @DisplayName("getActiveEmotions 메소드 테스트")
+    class GetActiveEmotionsTest {
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
+        class if_user_not_exists {
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 발생시킨다.")
+            void it_throws_UserNotFoundException() {
+                given(validateUserService.validateUserById(1L)).willThrow(
+                    new UserNotFoundException());
+
+                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L))
+                    .isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재할 경우")
+        class if_user_exists {
+
+            @Test
+            @DisplayName("활성화된 감정 목록을 반환한다.")
+            void it_returns_active_emotions() {
+                User user = createUserWithId(1L);
+                Emotion activeEmotion = createEmotion();
+                Emotion inActiveEmotion = createEmotionInActive();
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
+
+                List<GetActiveEmotionsResponse> emotions = emotionService.getActiveEmotions(1L);
+
+                assertThat(emotions.get(0).getId()).isEqualTo(activeEmotion.getEmotionId());
+                assertThat(emotions).extracting(GetActiveEmotionsResponse::getId)
+                    .isNotEqualTo(inActiveEmotion.getEmotionId());
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약
[GET] /emotions/all : 감정 목록 조회 API
- API 추가
- Service, Repository 테스트 추가

[POST] /emotions : 감정 등록 API
- API 추가
- Service 테스트 추가

### 기타
- 마지막 일기 생성 조회일 API의 예외 Swagger 명세 수정 : 불필요한 예외가 명시되어 있어 수정함


## 관련 이슈

close #31 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
