### PR TITLE
일기 조회 API가 이미지에 대해 Full S3 Url을 반환하도록 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import tipitapi.drawmytoday.diary.domain.Diary;
-import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 @Getter
@@ -43,8 +42,8 @@ public class GetDiaryResponse {
     @Schema(description = "일기 내용", requiredMode = RequiredMode.NOT_REQUIRED)
     private String notes;
 
-    public static GetDiaryResponse of(Diary diary, Image image, Emotion emotion) {
-        return new GetDiaryResponse(diary.getDiaryId(), image.getImageUrl(), diary.getDiaryDate(),
+    public static GetDiaryResponse of(Diary diary, String imageUrl, Emotion emotion) {
+        return new GetDiaryResponse(diary.getDiaryId(), imageUrl, diary.getDiaryDate(),
             diary.getCreatedAt(), emotion.getName(), diary.getNotes());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/s3/service/S3Util.java
+++ b/src/main/java/tipitapi/drawmytoday/s3/service/S3Util.java
@@ -1,0 +1,20 @@
+package tipitapi.drawmytoday.s3.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class S3Util {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String getFullUri(String uri) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, uri);
+    }
+}


### PR DESCRIPTION
S3 URI가 아니라, Full S3 URL을 반환하도록 수정

# 구현 내용

## 구현 요약

일기 조회 API : [GET] /diary/:id
-  기존에는 "post/3/123142_1.png"와 같이 S3 URI로 리턴하였는데, "https://버킷이름.s3.지역이름.amozon.com/이미지URI" 형식인 Full S3 URL로 리턴하도록 변경함
- S3 Service에 S3 Full URL을 만드는 메소드를 추가할 경우, DiaryService가 S3Client가 주입된 S3Service를 불필요하게 주입받게 되므로, 별도의 빈인 S3Util에 메소드를 추가해, S3Client 없는 비교적 가벼운 빈을 주입받도록 함

## 관련 이슈

close #36 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
