### PR TITLE
Swagger curl 요청 실패 문제 해결[배포]

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,11 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
     info = @Info(title = "오늘 하루를 그려줘 API 문서",
         description = "프로그라피 8기 4팀 TipiTapi의 오늘 하루를 그려줘 프로젝트의 API 문서입니다.",
-        version = "v1"))
+        version = "v1"),
+    servers = {
+        @Server(url = "https://draw-my-today.devstory.co.kr", description = "운영 서버"),
+    }
+)
 @Configuration
 @RequiredArgsConstructor
 public class SwaggerConfiguration {


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- swagger 도메인 운영서버 url http -> https로 변경

## 관련 이슈

close #40

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
