### PR TITLE
Feature/46

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -16,7 +16,7 @@ import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
-import tipitapi.drawmytoday.s3.service.S3Util;
+import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
 
@@ -28,7 +28,7 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final ImageService imageService;
     private final ValidateUserService validateUserService;
-    private final S3Util s3Util;
+    private final S3PreSignedService s3PreSignedService;
 
     public GetDiaryResponse getDiary(Long userId, Long diaryId) {
         User user = validateUserService.validateUserById(userId);
@@ -36,7 +36,9 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(DiaryNotFoundException::new);
         ownedByUser(diary, user);
-        String imageUrl = s3Util.getFullUri(imageService.getImage(diary).getImageUrl());
+
+        String imageUrl = s3PreSignedService.getPreSignedUrlForShare(
+            imageService.getImage(diary).getImageUrl(), 30);
 
         return GetDiaryResponse.of(diary, imageUrl, diary.getEmotion());
     }

--- a/src/main/java/tipitapi/drawmytoday/s3/service/S3PreSignedService.java
+++ b/src/main/java/tipitapi/drawmytoday/s3/service/S3PreSignedService.java
@@ -1,0 +1,45 @@
+package tipitapi.drawmytoday.s3.service;
+
+import static java.time.Duration.ofMinutes;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import tipitapi.drawmytoday.s3.exception.S3FailedException;
+
+@Service
+public class S3PreSignedService {
+
+    private final S3Presigner s3Presigner;
+
+    private final String bucketName;
+
+    public S3PreSignedService(@Value("${cloud.aws.s3.bucket}") String bucketName) {
+        this.s3Presigner = S3Presigner.create();
+        this.bucketName = bucketName;
+    }
+
+    /*
+     * S3 이미지 조회용 pre-signed URL 발급 메서드
+     */
+    public String getPreSignedUrlForShare(String objectKey, long expirationMin) {
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(bucketName)
+                .key(objectKey).build();
+
+            GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(ofMinutes(expirationMin))
+                .getObjectRequest(getObjectRequest).build();
+
+            return s3Presigner.presignGetObject(getObjectPresignRequest).url().toString();
+        } catch (SdkClientException | S3Exception e) {
+            throw e;
+        } catch (Exception e) {
+            throw new S3FailedException(e);
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/s3/service/S3Service.java
+++ b/src/main/java/tipitapi/drawmytoday/s3/service/S3Service.java
@@ -1,6 +1,6 @@
 package tipitapi.drawmytoday.s3.service;
 
-import static software.amazon.awssdk.services.s3.model.ObjectCannedACL.PUBLIC_READ;
+import static software.amazon.awssdk.services.s3.model.ObjectCannedACL.PRIVATE;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,6 +37,6 @@ public class S3Service {
             .bucket(bucketName)
             .key(filePath)
             .contentType("image/png")
-            .acl(PUBLIC_READ).build();
+            .acl(PRIVATE).build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/s3/service/S3Util.java
+++ b/src/main/java/tipitapi/drawmytoday/s3/service/S3Util.java
@@ -14,6 +14,11 @@ public class S3Util {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    /*
+     * 주어진 S3 URI의 Full S3 URL.
+     * 현재는 버킷의 퍼블릭 액세스 사용을 허용하지 않으므로, 이 URL을 사용해도 접근할 수 없다.
+     */
+    @Deprecated
     public String getFullUri(String uri) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, uri);
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약
PR 확인에 앞서, 이슈 확인 부탁드립니다.

- 객체 공유용 Pre Signed URL 발급 메소드 추가
   - S3PreSignedService 서비스 클래스 추가
   - getPreSignedUrlForShare 메소드 추가 : URI, URL 유효시간을 파라미터로 발급함
   - DiaryService의 getDiary에서 이미지 URL 리턴시, Pre Signed URL을 사용하도록 수정하였고, 30분 동안 URL이 유효하도록 처리함
   - Pre Signed URL이 만료되면 아래와 같이 접근이 제한됨
<img width="1512" alt="image" src="https://github.com/tipi-tapi/ai-paint-today-BE/assets/42285463/c3237eb3-f21e-4c9b-8ad7-fc5da603a02c">


- 기존의 URI를 통해 Full URI를 발급하는 메소드 deprecated 처리
  - S3Util 클래스의 getFullUri 메소드를 deprecated 처리함

- 이미지 업로드시 PRIVATE ACL로 업로드하도록 수정


## 관련 이슈

close #46 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
