### PR TITLE
소셜로그인 오류 해결 및 리팩토링

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: main branch cd
 
 on:
     push:
-        branches: [ "main", "test/auth" ]
+        branches: [ "main" ]
 
 env:
     PROD_PATH: ./src/main/resources/application-prod.yml

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: main branch cd
 
 on:
     push:
-        branches: [ "main" ]
+        branches: [ "main", "test/auth" ]
 
 env:
     PROD_PATH: ./src/main/resources/application-prod.yml

--- a/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
         "/oauth2/login",
         "/oauth2/google/login",
         "/oauth2/apple/login",
-        "/refresh"
+        "/oauth2/refresh"
     };
 
     @Bean

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     JWT_REFRESH_TOKEN_NOT_FOUND(404, "S004", "jwt refresh token이 없습니다."),
     EXPIRED_JWT_ACCESS_TOKEN(400, "S005", "jwt access token이 만료되었습니다."),
     EXPIRED_JWT_REFRESH_TOKEN(400, "S006", "jwt refresh token이 만료되었습니다."),
-    AUTH_CODE_NOT_FOUND(404, "S007", "인증 코드가 authorization header에 없습니다."),
+    AUTH_CODE_NOT_FOUND(404, "S007", "authorization header가 비었습니다."),
 
 
     // User
@@ -52,7 +52,9 @@ public enum ErrorCode {
     IMAGE_INPUT_STREAM_FAIL(500, "IIS001", "이미지 스트림을 가져오는데 실패하였습니다."),
 
     // OAuth
-    OAUTH_NOT_FOUND(404, "O001", "OAuth를 찾을 수 없습니다.");
+    OAUTH_NOT_FOUND(404, "O001", "OAuth를 찾을 수 없습니다."),
+    OAUTH_SERVER_FAILED(500, "O002", "OAuth 서버와의 통신 중 에러가 발생하였습니다.");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     IMAGE_INPUT_STREAM_FAIL(500, "IIS001", "이미지 스트림을 가져오는데 실패하였습니다."),
 
     // OAuth
-    OAUTH_NOT_FOUND(404, "O001", "OAuth를 찾을 수 없습니다."),
+    OAUTH_NOT_FOUND(404, "O001", "유저의 refresh token을 찾을 수 없습니다."),
     OAUTH_SERVER_FAILED(500, "O002", "OAuth 서버와의 통신 중 에러가 발생하였습니다.");
 
 

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(404, "U001", "회원을 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(409, "U002", "이미 존재하는 유저입니다."),
+    DUPLICATE_USER(400, "U003", "유저가 중복되었습니다."),
 
     // Diary
     DIARY_NOT_FOUND(404, "D001", "일기를 찾을 수 없습니다."),
@@ -48,7 +49,10 @@ public enum ErrorCode {
     DALLE_REQUEST_FAIL(500, "DE001", "DALL-E 요청에 실패하였습니다."),
 
     // Image InputStream
-    IMAGE_INPUT_STREAM_FAIL(500, "IIS001", "이미지 스트림을 가져오는데 실패하였습니다.");
+    IMAGE_INPUT_STREAM_FAIL(500, "IIS001", "이미지 스트림을 가져오는데 실패하였습니다."),
+
+    // OAuth
+    OAUTH_NOT_FOUND(404, "O001", "OAuth를 찾을 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<Object> handleBusinessException(BusinessException e) {
+        log.warn("handleBusinessException", e);
         ErrorCode errorCode = e.getErrorCode();
         return handleExceptionInternal(errorCode);
     }

--- a/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -87,6 +88,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ImageInputStreamFailException e) {
         log.error("ImageInputStreamFailException", e);
         return handleExceptionInternal(ErrorCode.IMAGE_INPUT_STREAM_FAIL);
+    }
+
+    @ExceptionHandler(RestClientException.class)
+    public ResponseEntity<Object> handleRestClientException(RestClientException e) {
+        log.error("RestClientException", e);
+        return handleExceptionInternal(ErrorCode.OAUTH_SERVER_FAILED);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationEntryPoint.java
@@ -25,13 +25,20 @@ public class JwtAuthenticationEntryPoint extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenException e) {
-            log.warn("exception info={}", e.getErrorCode(), e);
+            log.warn("security exception = {}", e.getErrorCode(), e);
             ErrorCode errorCode = e.getErrorCode();
-            response.setStatus(e.getErrorCode().getStatus());
-            ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(),
-                errorCode.getMessage(), null);
+
+            ErrorResponse errorResponse = makeErrorResponse(errorCode);
+            response.setStatus(errorCode.getStatus());
+            response.setCharacterEncoding("UTF-8");
             response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
         }
     }
 
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+            .code(errorCode.name())
+            .message(errorCode.getMessage())
+            .build();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
@@ -73,7 +73,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (Objects.isNull(authorization)) {
             throw new TokenNotFoundException(ErrorCode.JWT_ACCESS_TOKEN_NOT_FOUND);
         }
-        log.info("authorization: {}", authorization);
         String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
 
         if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
@@ -73,7 +73,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (Objects.isNull(authorization)) {
             throw new TokenNotFoundException(ErrorCode.JWT_ACCESS_TOKEN_NOT_FOUND);
         }
-
+        log.info("authorization: {}", authorization);
         String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
 
         if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -35,7 +35,7 @@ import tipitapi.drawmytoday.oauth.dto.ResponseAccessToken;
 import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.oauth.service.AppleOAuthService;
 import tipitapi.drawmytoday.oauth.service.GoogleOAuthService;
-import tipitapi.drawmytoday.user.domain.OAuthType;
+import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
@@ -126,9 +126,9 @@ public class AuthController {
             () -> new UserNotFoundException()
         );
 
-        if (user.getOauthType() == OAuthType.GOOGLE) {
+        if (user.getSocialCode() == SocialCode.GOOGLE) {
             googleOAuthService.deleteAccount(user);
-        } else if (user.getOauthType() == OAuthType.APPLE) {
+        } else if (user.getSocialCode() == SocialCode.APPLE) {
             appleOAuthService.deleteAccount(user);
         } else {
             throw new BusinessException(INTERNAL_SERVER_ERROR);

--- a/src/main/java/tipitapi/drawmytoday/oauth/domain/Auth.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/domain/Auth.java
@@ -37,4 +37,7 @@ public class Auth extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/dto/AppleIdToken.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/dto/AppleIdToken.java
@@ -1,5 +1,8 @@
 package tipitapi.drawmytoday.oauth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AppleIdToken {
 
     private String iss;

--- a/src/main/java/tipitapi/drawmytoday/oauth/dto/RequestAppleLogin.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/dto/RequestAppleLogin.java
@@ -1,13 +1,19 @@
 package tipitapi.drawmytoday.oauth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Schema(description = "애플 로그인 request")
 public class RequestAppleLogin {
 
+    @NotNull
+    @Schema(description = "애플 로그인 시 발급받은 id_token")
     private String idToken;
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/exception/OAuthNotFoundException.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/exception/OAuthNotFoundException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.oauth.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class OAuthNotFoundException extends BusinessException {
+
+    public OAuthNotFoundException() {
+        super(ErrorCode.OAUTH_NOT_FOUND);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -30,7 +30,7 @@ import tipitapi.drawmytoday.oauth.dto.RequestAppleLogin;
 import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.oauth.properties.AppleProperties;
 import tipitapi.drawmytoday.oauth.repository.AuthRepository;
-import tipitapi.drawmytoday.user.domain.OAuthType;
+import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
@@ -69,7 +69,7 @@ public class AppleOAuthService {
             .orElseGet(() -> {
                 return userRepository.save(User.builder()
                     .email(appleIdToken.getEmail())
-                    .oauthType(OAuthType.APPLE)
+                    .socialCode(SocialCode.APPLE)
                     .build());
             });
 

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -106,6 +106,8 @@ public class AppleOAuthService {
         if (response.contains("error")) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
         }
+
+        user.deleteUser();
     }
 
     private OAuthAccessToken getRefreshToken(String authorizationCode)

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -10,7 +10,6 @@ import java.util.Base64;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -37,7 +36,6 @@ import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -58,19 +56,12 @@ public class AppleOAuthService {
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin)
         throws IOException {
-        // authorization code 가져오기
         String authorizationCode = getAuthorizationCode(request);
-        log.info("authorizationCode={}", authorizationCode);
 
-        // authorization code로 refresh token 가져오기
         OAuthAccessToken oAuthAccessToken = getRefreshToken(authorizationCode);
-        log.info("getRefreshToken={}", oAuthAccessToken.getRefreshToken());
 
-        // appleIdToken 파싱
         AppleIdToken appleIdToken = getAppleIdToken(requestAppleLogin.getIdToken());
-        log.info("getEmail={}", appleIdToken.getEmail());
 
-        // save user info to database
         Optional<User> findUser = userRepository.findByEmail(appleIdToken.getEmail());
         User user = null;
         if (findUser.isPresent()) {
@@ -85,7 +76,6 @@ public class AppleOAuthService {
             authRepository.save(new Auth(user, oAuthAccessToken.getRefreshToken()));
         }
 
-        // // create JWT token
         String jwtAccessToken = jwtTokenProvider.createAccessToken(user.getUserId(),
             user.getUserRole());
         String jwtRefreshToken = jwtTokenProvider.createRefreshToken(user.getUserId(),

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -113,7 +113,7 @@ public class AppleOAuthService {
         String url = properties.getIosDeleteAccountUrl();
 
         String response = restTemplate.postForObject(url, request, String.class);
-        if (StringUtils.hasText(response)) {
+        if (response.contains("error")) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.oauth.service;
 
 import static tipitapi.drawmytoday.common.exception.ErrorCode.AUTH_CODE_NOT_FOUND;
-import static tipitapi.drawmytoday.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -96,7 +96,7 @@ public class AppleOAuthService {
 
         String response = restTemplate.postForObject(url, request, String.class);
         if (response != null) {
-            throw new BusinessException(INTERNAL_SERVER_ERROR);
+            throw new BusinessException(OAUTH_SERVER_FAILED);
         }
 
         user.deleteUser();

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -95,7 +95,7 @@ public class AppleOAuthService {
         String url = properties.getIosDeleteAccountUrl();
 
         String response = restTemplate.postForObject(url, request, String.class);
-        if (response.contains("error")) {
+        if (response != null) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
         }
 
@@ -109,7 +109,7 @@ public class AppleOAuthService {
 
         String clientId = properties.getIosClientId();
         String clientSecret = properties.getIosClientSecret();
-        String appleTokenUrl = "";
+        String appleTokenUrl = properties.getTokenUrl();
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -35,7 +34,6 @@ import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -56,16 +54,10 @@ public class GoogleOAuthService {
 
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request) throws JsonProcessingException {
-        // Authorization Code로 Access Token 요청
         OAuthAccessToken accessToken = getAccessToken(request);
-        log.info("getAccessToken = {}", accessToken.getAccessToken());
-        log.info("getRefreshToken = {}", accessToken.getRefreshToken());
 
-        // Access Token으로 User Info 요청
         OAuthUserProfile oAuthUserProfile = getUserProfile(accessToken);
-        log.info("oAuthUserProfile = {}", oAuthUserProfile.getEmail());
 
-        // save user info to database
         Optional<User> findUser = userRepository.findByEmail(oAuthUserProfile.getEmail());
         User user = null;
         if (findUser.isPresent()) {
@@ -119,7 +111,6 @@ public class GoogleOAuthService {
     private OAuthAccessToken getAccessToken(HttpServletRequest request)
         throws JsonProcessingException {
         String authorizationCode = getAuthorizationCode(request);
-        log.info("authorizationCode: {}", authorizationCode);
 
         String tokenUri = properties.getTokenUrl();
 

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -29,7 +29,7 @@ import tipitapi.drawmytoday.oauth.dto.OAuthUserProfile;
 import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.oauth.properties.GoogleProperties;
 import tipitapi.drawmytoday.oauth.repository.AuthRepository;
-import tipitapi.drawmytoday.user.domain.OAuthType;
+import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
@@ -66,7 +66,7 @@ public class GoogleOAuthService {
             .orElseGet(() -> {
                 return userRepository.save(User.builder()
                     .email(OAuthUserProfile.getEmail())
-                    .oauthType(OAuthType.GOOGLE)
+                    .socialCode(SocialCode.GOOGLE)
                     .build());
             });
 

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -111,7 +111,7 @@ public class GoogleOAuthService {
         String url = properties.getDeleteAccountUrl();
 
         String response = restTemplate.postForObject(url, request, String.class);
-        if (StringUtils.hasText(response)) {
+        if (response.contains("error")) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -1,6 +1,6 @@
 package tipitapi.drawmytoday.oauth.service;
 
-import static tipitapi.drawmytoday.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -96,7 +96,7 @@ public class GoogleOAuthService {
 
         String response = restTemplate.postForObject(url, request, String.class);
         if (response.contains("error")) {
-            throw new BusinessException(INTERNAL_SERVER_ERROR);
+            throw new BusinessException(OAUTH_SERVER_FAILED);
         }
 
         user.deleteUser();

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -106,6 +106,8 @@ public class GoogleOAuthService {
         if (response.contains("error")) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
         }
+
+        user.deleteUser();
     }
 
     private OAuthAccessToken getAccessToken(HttpServletRequest request)

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -74,8 +74,8 @@ public class GoogleOAuthService {
             auth.setRefreshToken(accessToken.getRefreshToken());
         } else {
             user = userRepository.save(User.builder()
-                .email(user.getEmail())
-                .socialCode(SocialCode.APPLE)
+                .email(oAuthUserProfile.getEmail())
+                .socialCode(SocialCode.GOOGLE)
                 .build());
             authRepository.save(new Auth(user, accessToken.getRefreshToken()));
         }

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
@@ -8,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
-import tipitapi.drawmytoday.user.exception.UserNotFoundException;
-import tipitapi.drawmytoday.user.repository.UserRepository;
+import tipitapi.drawmytoday.user.service.ValidateUserService;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,12 +17,10 @@ public class OAuthService {
 
     private final GoogleOAuthService googleOAuthService;
     private final AppleOAuthService appleOAuthService;
-    private final UserRepository userRepository;
+    private final ValidateUserService validateUserService;
 
     public void deleteAccount(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(
-            () -> new UserNotFoundException()
-        );
+        User user = validateUserService.validateUserById(userId);
         if (user.getSocialCode() == SocialCode.GOOGLE) {
             googleOAuthService.deleteAccount(user);
         } else if (user.getSocialCode() == SocialCode.APPLE) {

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
@@ -1,0 +1,35 @@
+package tipitapi.drawmytoday.oauth.service;
+
+import static tipitapi.drawmytoday.common.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.user.domain.SocialCode;
+import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.exception.UserNotFoundException;
+import tipitapi.drawmytoday.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final GoogleOAuthService googleOAuthService;
+    private final AppleOAuthService appleOAuthService;
+    private final UserRepository userRepository;
+
+    public void deleteAccount(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+            () -> new UserNotFoundException()
+        );
+        if (user.getSocialCode() == SocialCode.GOOGLE) {
+            googleOAuthService.deleteAccount(user);
+        } else if (user.getSocialCode() == SocialCode.APPLE) {
+            appleOAuthService.deleteAccount(user);
+        } else {
+            throw new BusinessException(INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/OAuthService.java
@@ -19,6 +19,7 @@ public class OAuthService {
     private final AppleOAuthService appleOAuthService;
     private final ValidateUserService validateUserService;
 
+    @Transactional
     public void deleteAccount(Long userId) {
         User user = validateUserService.validateUserById(userId);
         if (user.getSocialCode() == SocialCode.GOOGLE) {

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -36,6 +36,8 @@ public class User extends BaseEntityWithUpdate {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    private LocalDateTime deletedAt;
+
     private User(SocialCode socialCode) {
         this.socialCode = socialCode;
     }
@@ -61,5 +63,9 @@ public class User extends BaseEntityWithUpdate {
 
     public void setLastDiaryDate(LocalDateTime date) {
         this.lastDiaryDate = date;
+    }
+
+    public void deleteUser() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -34,25 +34,16 @@ public class User extends BaseEntityWithUpdate {
     private LocalDateTime lastDiaryDate;
 
     @Enumerated(EnumType.STRING)
-    private OAuthType oauthType;
-
-    @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     private User(SocialCode socialCode) {
         this.socialCode = socialCode;
     }
 
+    @Builder
     private User(String email, SocialCode socialCode) {
         this.email = email;
         this.socialCode = socialCode;
-    }
-
-    @Builder
-    private User(String email, SocialCode socialCode, OAuthType oauthType) {
-        this.email = email;
-        this.socialCode = socialCode;
-        this.oauthType = oauthType;
         this.userRole = UserRole.USER;
     }
 

--- a/src/main/java/tipitapi/drawmytoday/user/exception/DuplicateUserException.java
+++ b/src/main/java/tipitapi/drawmytoday/user/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.user.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class DuplicateUserException extends BusinessException {
+
+    public DuplicateUserException() {
+        super(ErrorCode.DUPLICATE_USER);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.user.domain.User;
@@ -8,5 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
 
-    Optional<User> findByEmail(String email);
+    List<User> findAllByEmail(String email);
 }

--- a/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
@@ -6,5 +6,7 @@ import tipitapi.drawmytoday.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/tipitapi/drawmytoday/user/service/UserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/UserService.java
@@ -1,0 +1,25 @@
+package tipitapi.drawmytoday.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.user.domain.SocialCode;
+import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User registerUser(String email, SocialCode socialCode) {
+        User user = User.builder()
+            .email(email)
+            .socialCode(socialCode)
+            .build();
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -15,6 +15,7 @@ public class ValidateUserService {
     private final UserRepository userRepository;
 
     public User validateUserById(Long userId) {
-        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        return userRepository.findByUserIdAndDeletedAtIsNull(userId)
+            .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
@@ -17,5 +18,12 @@ public class ValidateUserService {
     public User validateUserById(Long userId) {
         return userRepository.findByUserIdAndDeletedAtIsNull(userId)
             .orElseThrow(UserNotFoundException::new);
+    }
+
+    public User validateRegisteredUserByEmail(String email, SocialCode socialCode) {
+        return userRepository.findAllByEmail(email).stream()
+            .filter(user -> user.getDeletedAt() == null && user.getSocialCode() == socialCode)
+            .findFirst()
+            .orElse(null);
     }
 }


### PR DESCRIPTION
# 구현 내용

__구글, 애플 소셜로그인(회원가입), 회원탈퇴 기능 리팩토링 및 테스트 완료__

## 구현 요약

- 소셜로그인 성공시 유저의 이메일 대조 뿐만 아니라 delete 유무까지 확인하여 회원가입한 유저인지 체크하도록 변경

- 구글, 애플 소셜로그인 탈퇴 기능 구현
  - 탈퇴 요청 성공시 소셜로그인 탈퇴
  - 탈퇴 요청 성공시 유저를 db에서 삭제하는 것이 아닌 deletedAt으로 탈퇴 시각을 저장하도록 구현(재 회원가입시 새로운 유저 생성)

- 프론트에서 탈퇴 요청을 보낼 때 토큰 만료시 access token 재발급 요청을 먼저 보내 토큰을 재발급받고, 탈퇴 요청을 보내는 시나리오 테스트 완료

- swagger에 oauth 요청시 발생할 수 있는 모든 에러 명시 완료

- 에러 메시지 인코딩 실패 오류 해결

- user 엔티티에 oauth_type 필드 삭제(social_code와 중복)
```
로컬 서버에도 적용해주세요!
alter table user drop oauth_type;
```

## 관련 이슈

close #21 #44 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
