### PR TITLE
JWT 토큰 만료 API(테스트용) 및 Swagger security 등록 방식 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
         "/oauth2/login",
         "/oauth2/google/login",
         "/oauth2/apple/login",
-        "/oauth2/refresh"
+        "/oauth2/refresh",
+        "/oauth2/expiredJwt"
     };
 
     @Bean

--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -1,13 +1,13 @@
 package tipitapi.drawmytoday.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.GroupedOpenApi;
-import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,6 +20,13 @@ import org.springframework.context.annotation.Configuration;
     }
 )
 @Configuration
+@SecurityScheme(
+    name = "Bearer Authentication",
+    type = SecuritySchemeType.HTTP,
+    in = SecuritySchemeIn.HEADER,
+    bearerFormat = "JWT",
+    scheme = "bearer"
+)
 @RequiredArgsConstructor
 public class SwaggerConfiguration {
 
@@ -31,7 +38,7 @@ public class SwaggerConfiguration {
             .builder()
             .group("유저 API")
             .pathsToMatch(paths)
-            .addOpenApiCustomiser(buildSecurityOpenApi()).build();
+            .build();
     }
 
     @Bean
@@ -42,7 +49,7 @@ public class SwaggerConfiguration {
             .builder()
             .group("일기 API")
             .pathsToMatch(paths)
-            .addOpenApiCustomiser(buildSecurityOpenApi()).build();
+            .build();
     }
 
     @Bean
@@ -53,7 +60,7 @@ public class SwaggerConfiguration {
             .builder()
             .group("감정 API")
             .pathsToMatch(paths)
-            .addOpenApiCustomiser(buildSecurityOpenApi()).build();
+            .build();
     }
 
     @Bean
@@ -64,17 +71,6 @@ public class SwaggerConfiguration {
             .builder()
             .group("OAuth2 API")
             .pathsToMatch(paths)
-            .addOpenApiCustomiser(buildSecurityOpenApi()).build();
-    }
-
-    public OpenApiCustomiser buildSecurityOpenApi() {
-        // jwt token 을 한번 설정하면 header 에 값을 넣어주는 코드
-        return OpenApi -> OpenApi.addSecurityItem(new SecurityRequirement().addList("jwt token"))
-            .getComponents().addSecuritySchemes("jwt token", new SecurityScheme()
-                .name("Authorization")
-                .type(SecurityScheme.Type.HTTP)
-                .in(SecurityScheme.In.HEADER)
-                .bearerFormat("JWT")
-                .scheme("bearer"));
+            .build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     EXPIRED_JWT_ACCESS_TOKEN(400, "S005", "jwt access token이 만료되었습니다."),
     EXPIRED_JWT_REFRESH_TOKEN(400, "S006", "jwt refresh token이 만료되었습니다."),
     AUTH_CODE_NOT_FOUND(404, "S007", "authorization header가 비었습니다."),
+    JWT_TOKEN_NOT_FOUND(404, "S008", "jwt token이 없습니다."),
 
 
     // User

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package tipitapi.drawmytoday.common.security.jwt;
 
 import java.io.IOException;
-import java.util.Objects;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -11,14 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
-import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.filter.OncePerRequestFilter;
-import tipitapi.drawmytoday.common.exception.ErrorCode;
 import tipitapi.drawmytoday.common.security.jwt.exception.ExpiredAccessTokenException;
 import tipitapi.drawmytoday.common.security.jwt.exception.InvalidTokenException;
 import tipitapi.drawmytoday.common.security.jwt.exception.TokenNotFoundException;
+import tipitapi.drawmytoday.common.utils.HeaderUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,11 +25,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private final String[] permitAllEndpointList;
-
-    private static HttpServletRequest getRequest() {
-        ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
-        return servletRequestAttributes.getRequest();
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -59,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      * @throws ExpiredAccessTokenException - 헤더에 토큰이 있지만 만료된 경우
      */
     private void authentication() {
-        String accessToken = getAccessToken();
+        String accessToken = HeaderUtils.getJwtToken(getRequest(), JwtType.ACCESS);
 
         jwtTokenProvider.validAccessToken(accessToken);
 
@@ -67,19 +60,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    private String getAccessToken() {
-        String authorization = getRequest().getHeader(JwtProperties.ACCESS_TOKEN_HEADER);
-
-        if (Objects.isNull(authorization)) {
-            throw new TokenNotFoundException(ErrorCode.JWT_ACCESS_TOKEN_NOT_FOUND);
-        }
-        String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
-
-        if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {
-            throw new InvalidTokenException();
-        }
-
-        return tokens[1];
+    private HttpServletRequest getRequest() {
+        ServletRequestAttributes servletRequestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        return servletRequestAttributes.getRequest();
     }
-
 }

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtProperties.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtProperties.java
@@ -2,8 +2,7 @@ package tipitapi.drawmytoday.common.security.jwt;
 
 public class JwtProperties {
 
-    public static final String ACCESS_TOKEN_HEADER = "Authorization";
-    public static final String REFRESH_TOKEN_HEADER = "Authorization";
+    public static final String JWT_TOKEN_HEADER = "Authorization";
 
     public static final String USER_ID = "userId";
     public static final String ROLE = "AuthenticationRole";

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtTokenProvider.java
@@ -79,6 +79,15 @@ public class JwtTokenProvider {
         return createToken(userId, userRole, REFRESH_TOKEN_EXPIRE_TIME);
     }
 
+    public String expireToken(String jwtToken) {
+        Claims claims = parseClaims(jwtToken);
+        return Jwts.builder()
+            .setClaims(claims)
+            .setExpiration(new Date())
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+    }
+
     public String createNewAccessTokenFromRefreshToken(String refreshToken) {
         Claims claims = parseClaims(refreshToken);
 

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtType.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtType.java
@@ -1,0 +1,5 @@
+package tipitapi.drawmytoday.common.security.jwt;
+
+public enum JwtType {
+    ACCESS, REFRESH, BOTH
+}

--- a/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
@@ -1,0 +1,41 @@
+package tipitapi.drawmytoday.common.utils;
+
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+import tipitapi.drawmytoday.common.security.jwt.JwtProperties;
+import tipitapi.drawmytoday.common.security.jwt.JwtType;
+import tipitapi.drawmytoday.common.security.jwt.exception.InvalidTokenException;
+import tipitapi.drawmytoday.common.security.jwt.exception.TokenNotFoundException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HeaderUtils {
+
+    /**
+     * @throws TokenNotFoundException - 헤더에 토큰이 없는 경우
+     * @throws InvalidTokenException  - 헤더에 토큰이 있지만 유효하지 않은 경우
+     */
+    public static String getJwtToken(HttpServletRequest request, JwtType jwtType) {
+        String authorization = request.getHeader(JwtProperties.JWT_TOKEN_HEADER);
+
+        if (Objects.isNull(authorization)) {
+            if (jwtType == JwtType.ACCESS) {
+                throw new TokenNotFoundException(ErrorCode.JWT_TOKEN_NOT_FOUND);
+            } else if (jwtType == JwtType.REFRESH) {
+                throw new TokenNotFoundException(ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND);
+            } else if (jwtType == JwtType.BOTH) {
+                throw new TokenNotFoundException(ErrorCode.JWT_TOKEN_NOT_FOUND);
+            }
+        }
+        String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
+
+        if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {
+            throw new InvalidTokenException();
+        }
+
+        return tokens[1];
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -84,8 +84,8 @@ public class DiaryController {
     })
     @GetMapping("/calendar/monthly")
     public ResponseEntity<SuccessResponse<List<GetMonthlyDiariesResponse>>> getMonthlyDiaries(
-        @Parameter(description = "조회할 연도", in = ParameterIn.PATH) @RequestParam("year") int year,
-        @Parameter(description = "조회할 달", in = ParameterIn.PATH) @RequestParam("month") int month
+        @Parameter(description = "조회할 연도", in = ParameterIn.QUERY) @RequestParam("year") int year,
+        @Parameter(description = "조회할 달", in = ParameterIn.QUERY) @RequestParam("month") int month
         , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,7 @@ import tipitapi.drawmytoday.diary.service.DiaryService;
 @RestController
 @RequestMapping("/diary")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Authentication")
 public class DiaryController {
 
     private final DiaryService diaryService;

--- a/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import tipitapi.drawmytoday.emotion.service.EmotionService;
 @RestController
 @RequestMapping("/emotions")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Authentication")
 public class EmotionController {
 
     private final EmotionService emotionService;

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -1,7 +1,5 @@
 package tipitapi.drawmytoday.oauth.controller;
 
-import static tipitapi.drawmytoday.common.exception.ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,13 +7,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.io.IOException;
-import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,11 +20,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
-import tipitapi.drawmytoday.common.security.jwt.JwtProperties;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
-import tipitapi.drawmytoday.common.security.jwt.exception.InvalidTokenException;
-import tipitapi.drawmytoday.common.security.jwt.exception.TokenNotFoundException;
+import tipitapi.drawmytoday.common.security.jwt.JwtType;
+import tipitapi.drawmytoday.common.utils.HeaderUtils;
 import tipitapi.drawmytoday.oauth.dto.RequestAppleLogin;
 import tipitapi.drawmytoday.oauth.dto.ResponseAccessToken;
 import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
@@ -111,7 +106,7 @@ public class AuthController {
     })
     @GetMapping("/refresh")
     public ResponseAccessToken getAccessToken(HttpServletRequest request) {
-        String refreshToken = getRefreshToken(request);
+        String refreshToken = HeaderUtils.getJwtToken(request, JwtType.REFRESH);
         jwtTokenProvider.validRefreshToken(refreshToken);
         String accessToken = jwtTokenProvider.createNewAccessTokenFromRefreshToken(refreshToken);
         return ResponseAccessToken.of(accessToken);
@@ -139,16 +134,24 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    private String getRefreshToken(HttpServletRequest request) {
-        String authorization = request.getHeader(JwtProperties.REFRESH_TOKEN_HEADER);
-        if (Objects.isNull(authorization)) {
-            throw new TokenNotFoundException(JWT_REFRESH_TOKEN_NOT_FOUND);
-        }
-        String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
-        if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {
-            throw new InvalidTokenException();
-        }
-        return tokens[1];
+    @Operation(summary = "토큰 만료(테스트)", description = "jwt token을 만료시킵니다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "jwt token 만료 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "S002 : 유효하지 않은 토큰입니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "S008 : jwt token이 없습니다.",
+            content = @Content(schema = @Schema(hidden = true)))
+    })
+    @GetMapping("/expiredJwt")
+    public String getExpiredJwt(HttpServletRequest request) {
+        String jwtToken = HeaderUtils.getJwtToken(request, JwtType.BOTH);
+        return jwtTokenProvider.expireToken(jwtToken);
     }
 
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -134,7 +135,8 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "토큰 만료(테스트)", description = "jwt token을 만료시킵니다.")
+    @Operation(summary = "토큰 만료(테스트)", description = "jwt token을 만료시킵니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication"))
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -148,7 +148,7 @@ public class AuthController {
             description = "S008 : jwt token이 없습니다.",
             content = @Content(schema = @Schema(hidden = true)))
     })
-    @GetMapping("/expiredJwt")
+    @GetMapping("/expire")
     public String getExpiredJwt(HttpServletRequest request) {
         String jwtToken = HeaderUtils.getJwtToken(request, JwtType.BOTH);
         return jwtTokenProvider.expireToken(jwtToken);

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -113,7 +113,8 @@ public class AuthController {
         return ResponseAccessToken.of(accessToken);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "소셜로그인 탈퇴를 진행하고, 회원을 deleted 상태로 변경합니다.")
+    @Operation(summary = "회원 탈퇴", description = "소셜로그인 탈퇴를 진행하고, 회원을 deleted 상태로 변경합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication"))
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "204",


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 테스트용 JWT 토큰 만료 API 구현
- request header 안에 토큰 가져오는 로직 통일화
- swagger security scheme 등록 방식 bean -> annotation으로 변경 (일부 예외상황 설정을 편하게 하기 위해)
- jwt 토큰이 필요없는 api의 경우 authorization 헤더에 토큰이 등록되지 않도록 변경

## 관련 이슈

close #53 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
