### PR TITLE
일기 삭제 API 추가, ID 의존적이지 않은 Diary Repository Test로 리팩토링

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -12,6 +12,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -157,6 +158,29 @@ public class DiaryController {
     ) {
         diaryService.updateDiaryNotes(tokenInfo.getUserId(), diaryId,
             updateDiaryRequest.getNotes());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "일기 삭제", description = "주어진 ID의 일기를 삭제(Soft Delete)한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 일기 내용을 삭제함"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDiary(
+        @AuthUser JwtTokenInfo tokenInfo,
+        @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId
+    ) {
+        diaryService.deleteDiary(tokenInfo.getUserId(), diaryId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -19,10 +19,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.user.domain.User;
 
+
+@SQLDelete(sql = "UPDATE diary SET deleted_at = current_timestamp WHERE diary_id = ?")
+@Where(clause = "deleted_at is null")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -64,6 +69,8 @@ public class Diary extends BaseEntityWithUpdate {
 
     @OneToMany(mappedBy = "diary")
     private List<Image> imageList;
+
+    private LocalDateTime deletedAt;
 
     @Builder
     public Diary(User user, Emotion emotion, LocalDateTime diaryDate, String notes, boolean isAi,

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -14,4 +14,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         LocalDateTime endMonth);
 
     Optional<Diary> findFirstByUserUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Diary> findFirstByDiaryId(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -12,9 +12,7 @@ import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
-import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
-import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 import tipitapi.drawmytoday.user.domain.User;
@@ -29,13 +27,12 @@ public class DiaryService {
     private final ImageService imageService;
     private final ValidateUserService validateUserService;
     private final S3PreSignedService s3PreSignedService;
+    private final ValidateDiaryService validateDiaryService;
 
     public GetDiaryResponse getDiary(Long userId, Long diaryId) {
         User user = validateUserService.validateUserById(userId);
 
-        Diary diary = diaryRepository.findById(diaryId)
-            .orElseThrow(DiaryNotFoundException::new);
-        ownedByUser(diary, user);
+        Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
 
         String imageUrl = s3PreSignedService.getPreSignedUrlForShare(
             imageService.getImage(diary).getImageUrl(), 30);
@@ -63,9 +60,7 @@ public class DiaryService {
     @Transactional
     public void updateDiaryNotes(Long userId, Long diaryId, String notes) {
         User user = validateUserService.validateUserById(userId);
-        Diary diary = diaryRepository.findById(diaryId)
-            .orElseThrow(DiaryNotFoundException::new);
-        ownedByUser(diary, user);
+        Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
 
         diary.setNotes(notes);
     }
@@ -80,11 +75,5 @@ public class DiaryService {
             })
             .map(GetMonthlyDiariesResponse::of)
             .collect(Collectors.toList());
-    }
-
-    private void ownedByUser(Diary diary, User user) {
-        if (diary.getUser() != user) {
-            throw new NotOwnerOfDiaryException();
-        }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -65,6 +65,14 @@ public class DiaryService {
         diary.setNotes(notes);
     }
 
+    @Transactional
+    public void deleteDiary(Long userId, Long diaryId) {
+        User user = validateUserService.validateUserById(userId);
+        Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
+
+        diaryRepository.delete(diary);
+    }
+
     private List<GetMonthlyDiariesResponse> convertDiariesToResponse(List<Diary> getDiaryList) {
         return getDiaryList.stream()
             .filter(diary -> {

--- a/src/main/java/tipitapi/drawmytoday/diary/service/ValidateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/ValidateDiaryService.java
@@ -1,0 +1,31 @@
+package tipitapi.drawmytoday.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
+import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
+import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+import tipitapi.drawmytoday.user.domain.User;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ValidateDiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    public Diary validateDiaryById(Long diaryId, User user) {
+        Diary diary = diaryRepository.findFirstByDiaryId(diaryId)
+            .orElseThrow(DiaryNotFoundException::new);
+        ownedByUser(diary, user);
+        return diary;
+    }
+
+    private void ownedByUser(Diary diary, User user) {
+        if (diary.getUser() != user) {
+            throw new NotOwnerOfDiaryException();
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/common/BaseRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/common/BaseRepositoryTest.java
@@ -1,12 +1,11 @@
 package tipitapi.drawmytoday.common;
 
-import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import tipitapi.drawmytoday.common.testdata.TestDiary;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.common.testdata.TestImage;
 import tipitapi.drawmytoday.common.testdata.TestUser;
 import tipitapi.drawmytoday.diary.domain.Diary;
@@ -46,6 +45,10 @@ public abstract class BaseRepositoryTest {
 
     protected Image createImage(Long imageId, Diary diary) {
         return imageRepository.save(TestImage.createImageWithId(imageId, diary));
+    }
+
+    protected Emotion createEmotion() {
+        return emotionRepository.save(TestEmotion.createEmotion());
     }
 
 }

--- a/src/test/java/tipitapi/drawmytoday/common/BaseRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/common/BaseRepositoryTest.java
@@ -35,9 +35,13 @@ public abstract class BaseRepositoryTest {
         return userRepository.save(TestUser.createUser());
     }
 
-    protected Diary createDiary(Long diaryId, User user) {
+    protected Diary createDiaryWithId(Long diaryId, User user) {
         Emotion emotion = emotionRepository.save(createEmotion());
         return diaryRepository.save(TestDiary.createDiaryWithId(diaryId, user, emotion));
+    }
+
+    protected Diary createDiary(User user, Emotion emotion) {
+        return diaryRepository.save(TestDiary.createDiary(user, emotion));
     }
 
     protected Image createImage(Long imageId, Diary diary) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -19,10 +19,8 @@ public class TestDiary {
         return diary;
     }
 
-    public static Diary createDiaryWithIdAndDate(Long diaryId, LocalDateTime diaryDate, User user,
-        Emotion emotion) {
+    public static Diary createDiaryWithDate(LocalDateTime diaryDate, User user, Emotion emotion) {
         Diary diary = createDiary(user, emotion);
-        ReflectionTestUtils.setField(diary, "diaryId", diaryId);
         ReflectionTestUtils.setField(diary, "diaryDate", diaryDate);
         return diary;
     }
@@ -32,6 +30,13 @@ public class TestDiary {
         Emotion emotion) {
         Diary diary = createDiary(user, emotion);
         ReflectionTestUtils.setField(diary, "diaryId", diaryId);
+        ReflectionTestUtils.setField(diary, "createdAt", createdAt);
+        return diary;
+    }
+
+    public static Diary createDiaryWithCreatedAt(LocalDateTime createdAt, User user,
+        Emotion emotion) {
+        Diary diary = createDiary(user, emotion);
         ReflectionTestUtils.setField(diary, "createdAt", createdAt);
         return diary;
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -41,8 +41,7 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
             @Test
             @DisplayName("일기를 반환한다.")
             void return_diary() {
-                User user = createUser();
-                Diary diary = createDiary(1L, user);
+                Diary diary = createDiary(createUser(), createEmotion());
 
                 Optional<Diary> foundDiary = diaryRepository.findById(1L);
 

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/ImageRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/ImageRepositoryTest.java
@@ -33,7 +33,7 @@ class ImageRepositoryTest extends BaseRepositoryTest {
             @Test
             @DisplayName("이미지를 반환한다.")
             void return_image() {
-                Diary diary = createDiary(1L, createUser());
+                Diary diary = createDiaryWithId(1L, createUser());
                 Image image = createImage(1L, diary);
 
                 Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(diary);
@@ -50,7 +50,7 @@ class ImageRepositoryTest extends BaseRepositoryTest {
             @Test
             @DisplayName("null을 반환한다.")
             void return_null() {
-                Diary diary = createDiary(1L, createUser());
+                Diary diary = createDiaryWithId(1L, createUser());
                 createImage(1L, diary).setSelected(false);
 
                 Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(diary);
@@ -67,8 +67,8 @@ class ImageRepositoryTest extends BaseRepositoryTest {
             @DisplayName("null을 반환한다.")
             void return_null() {
                 User user = createUser();
-                Diary diary = createDiary(1L, user);
-                Diary otherDiary = createDiary(2L, user);
+                Diary diary = createDiaryWithId(1L, user);
+                Diary otherDiary = createDiaryWithId(2L, user);
                 createImage(1L, diary);
 
                 Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -77,8 +77,8 @@ class DiaryServiceTest {
         }
 
         @Nested
-        @DisplayName("주어진 일기가 없을 경우")
-        class if_diary_not_exists_or_not_user_owned_diary {
+        @DisplayName("주어진 일기가 없거나 삭제되었을 경우")
+        class if_diary_not_exists_or_deleted {
 
             @Test
             @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
@@ -112,8 +112,8 @@ class DiaryServiceTest {
     }
 
     @Nested
-    @DisplayName("getDiaries 메소드 테스트")
-    class GetDiariesTest {
+    @DisplayName("getMonthlyDiaries 메소드 테스트")
+    class GetMonthlyDiariesTest {
 
         @Nested
         @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -33,6 +33,7 @@ import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
@@ -46,6 +47,8 @@ class DiaryServiceTest {
     ImageService imageService;
     @Mock
     ValidateUserService validateUserService;
+    @Mock
+    S3PreSignedService s3PreSignedService;
     @Mock
     ValidateDiaryService validateDiaryService;
     @InjectMocks
@@ -69,6 +72,9 @@ class DiaryServiceTest {
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(validateDiaryService.validateDiaryById(1L, user)).willReturn(diary);
                 given(imageService.getImage(diary)).willReturn(image);
+                given(
+                    s3PreSignedService.getPreSignedUrlForShare(any(String.class), any(Long.class))
+                ).willReturn("https://test.com");
 
                 GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L);
 

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -46,6 +46,8 @@ class DiaryServiceTest {
     ImageService imageService;
     @Mock
     ValidateUserService validateUserService;
+    @Mock
+    ValidateDiaryService validateDiaryService;
     @InjectMocks
     DiaryService diaryService;
 
@@ -65,8 +67,7 @@ class DiaryServiceTest {
                 Image image = createImage(diary);
 
                 given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(diaryRepository.findById(1L)).willReturn(
-                    Optional.of(diary));
+                given(validateDiaryService.validateDiaryById(1L, user)).willReturn(diary);
                 given(imageService.getImage(diary)).willReturn(image);
 
                 GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L);
@@ -82,8 +83,10 @@ class DiaryServiceTest {
             @Test
             @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
             void it_throws_DiaryNotFoundException() {
-                given(diaryRepository.findById(1L)).willReturn(Optional.empty());
-                given(validateUserService.validateUserById(1L)).willReturn(createUser());
+                User user = createUser();
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(validateDiaryService.validateDiaryById(1L, user)).willThrow(
+                    DiaryNotFoundException.class);
 
                 assertThatThrownBy(() -> diaryService.getDiary(1L, 1L))
                     .isInstanceOf(DiaryNotFoundException.class);
@@ -97,11 +100,10 @@ class DiaryServiceTest {
             @Test
             @DisplayName("NotOwnerOfDiaryException 예외를 발생시킨다.")
             void it_throws_NotOwnerOfDiaryException() {
-                createUserWithId(1L);
-                User otherUser = createUserWithId(2L);
-                Diary diary = createDiaryWithId(1L, otherUser, createEmotion());
-
-                given(diaryRepository.findById(1L)).willReturn(Optional.of(diary));
+                User user = createUserWithId(1L);
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(validateDiaryService.validateDiaryById(1L, user))
+                    .willThrow(NotOwnerOfDiaryException.class);
 
                 assertThatThrownBy(() -> diaryService.getDiary(1L, 1L))
                     .isInstanceOf(NotOwnerOfDiaryException.class);
@@ -282,8 +284,8 @@ class DiaryServiceTest {
             void it_throws_DiaryNotFoundException() {
                 User user = createUserWithId(1L);
                 given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(diaryRepository.findById(any(Long.class)))
-                    .willReturn(Optional.empty());
+                given(validateDiaryService.validateDiaryById(1L, user))
+                    .willThrow(DiaryNotFoundException.class);
 
                 assertThatThrownBy(() -> diaryService.updateDiaryNotes(1L, 1L, "notes"))
                     .isInstanceOf(DiaryNotFoundException.class);
@@ -304,8 +306,8 @@ class DiaryServiceTest {
                     User user = createUserWithId(1L);
                     Diary diary = createDiaryWithId(1L, user, createEmotion());
                     given(validateUserService.validateUserById(1L)).willReturn(user);
-                    given(diaryRepository.findById(any(Long.class)))
-                        .willReturn(Optional.of(diary));
+                    given(validateDiaryService.validateDiaryById(1L, user))
+                        .willReturn(diary);
 
                     diaryService.updateDiaryNotes(1L, 1L, null);
 
@@ -323,8 +325,8 @@ class DiaryServiceTest {
                     User user = createUserWithId(1L);
                     Diary diary = createDiaryWithId(1L, user, createEmotion());
                     given(validateUserService.validateUserById(1L)).willReturn(user);
-                    given(diaryRepository.findById(any(Long.class)))
-                        .willReturn(Optional.of(diary));
+                    given(validateDiaryService.validateDiaryById(1L, user))
+                        .willReturn(diary);
 
                     diaryService.updateDiaryNotes(1L, 1L, "notes");
 

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -337,4 +337,41 @@ class DiaryServiceTest {
         }
 
     }
+
+    @Nested
+    @DisplayName("deleteDiary 메소드 테스트")
+    class DeleteDiaryTest {
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
+        class if_user_not_exists {
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 발생시킨다.")
+            void it_throws_UserNotFoundException() {
+                given(validateUserService.validateUserById(1L)).willThrow(
+                    new UserNotFoundException());
+
+                assertThatThrownBy(() -> diaryService.deleteDiary(1L, 1L))
+                    .isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("diaryId에 해당하는 일기가 존재하지 않을 경우")
+        class if_diary_not_exists {
+
+            @Test
+            @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
+            void it_throws_DiaryNotFoundException() {
+                User user = createUserWithId(1L);
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(validateDiaryService.validateDiaryById(1L, user))
+                    .willThrow(DiaryNotFoundException.class);
+
+                assertThatThrownBy(() -> diaryService.deleteDiary(1L, 1L))
+                    .isInstanceOf(DiaryNotFoundException.class);
+            }
+        }
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/ValidateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/ValidateDiaryServiceTest.java
@@ -1,0 +1,108 @@
+package tipitapi.drawmytoday.diary.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
+import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.testdata.TestDiary;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
+import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
+import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
+import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+import tipitapi.drawmytoday.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class ValidateDiaryServiceTest {
+
+    @Mock
+    DiaryRepository diaryRepository;
+
+    @InjectMocks
+    ValidateDiaryService validateDiaryService;
+
+    @Nested
+    @DisplayName("validateDiaryById 메소드 테스트")
+    class ValidateDiaryByIdTest {
+
+        @Nested
+        @DisplayName("diaryId에 해당하는 일기가 존재하지 않을 경우")
+        class if_diary_not_exists {
+
+            @Test
+            @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
+            void it_throws_DiaryNotFoundException() {
+                given(diaryRepository.findFirstByDiaryId(any(Long.class)))
+                    .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> validateDiaryService.validateDiaryById(1L, createUser()))
+                    .isInstanceOf(DiaryNotFoundException.class);
+            }
+
+        }
+
+        @Nested
+        @DisplayName("user 소유의 일기가 아닌 경우")
+        class if_not_owner_of_diary {
+
+            @Test
+            @DisplayName("NotOwnerOfDiaryException 예외를 발생시킨다.")
+            void it_throws_NotOwnerOfDiaryException() {
+                User user = createUserWithId(1L);
+                Diary diary = TestDiary.createDiaryWithId(
+                    1L, createUserWithId(2L), TestEmotion.createEmotion());
+                given(diaryRepository.findFirstByDiaryId(any(Long.class)))
+                    .willReturn(Optional.of(diary));
+
+                assertThatThrownBy(() -> validateDiaryService.validateDiaryById(1L, user))
+                    .isInstanceOf(NotOwnerOfDiaryException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("일기가 삭제된 경우")
+        class if_diary_deleted {
+
+            @Test
+            @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
+            void it_throws_DiaryNotFoundException() {
+                given(diaryRepository.findFirstByDiaryId(any(Long.class)))
+                    .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> validateDiaryService.validateDiaryById(1L, createUser()))
+                    .isInstanceOf(DiaryNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("일기가 존재할 경우")
+        class if_diary_exists {
+
+            @Test
+            @DisplayName("일기를 삭제한다.")
+            void return_diary() {
+                User user = createUserWithId(1L);
+                Diary diary = createDiaryWithId(1L, user, createEmotion());
+                given(diaryRepository.findFirstByDiaryId(any(Long.class)))
+                    .willReturn(Optional.of(diary));
+
+                Diary validatedDiary = validateDiaryService.validateDiaryById(1L, user);
+
+                assertThat(validatedDiary).isEqualTo(diary);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약
### 일기 삭제 API 추가
- [DELETE] /diary/:id 추가
- Diary 엔티티에 deletedAt 필드 추가
- Diary 엔티티는 SoftDelete 처리되도록, delete 요청시 deletedAt이 변경되는 SQLDelete 어노테이션을 추가함
- Diary 엔티티에 대해 DB로 쿼리를 입력할때, 언제나 deletedAt != null인 것만 받아올 수 있도록 Where 어노테이션으로 적용함
   - `@Where(clause = "deleted_at is null")`
   - 위 코드를 통해서, DB로 Diary 엔티티에 대한 쿼리를 날릴 때 `deleted_at is null`이라는 SQL 문이 자동으로 추가됨
   - 따라서, DiaryRepository에 메소드를 추가할때 반복적으로 `~DeletedAtIsNull`를 추가하는 작업이 필요 없음

### ValidateDiaryService 클래스 추가
- 주어진 일기 ID로, 일기를 찾아서, 소유 여부를 검증하는 서비스 메소드 추가
- 일기를 찾을 때는 언제나 소유 여부를 검증하므로, 하나의 서비스 클래스에서 처리하는게 좋다고 생각되어 분리함
- DiaryRepository에 findFirstByDiaryId 메소드를 추가하여, 주어진 ID로 

### DiaryService 테스트내 단위테스트 이름 변경
- 일부 테스트의 클래스명이 적합하지 않아 수정함

### ID 의존적이지 않은 Repository Test로 수정
- Repository Test에는 ID 의존적인 테스트가 많이 작성되어 있음
- 예를 들어, 1L의 ID값을 가진 일기를 생성해서, `assert(result.getDiaryId).isEqualTo(1L);`와 같이 검증함
- 하지만, Run All Test를 통해 일괄적으로 이러한 테스트를 실행할 경우, 각 테스트가 끝나면서 데이터가 롤백되지만 auto-increment는 롤백되지 않음
- 따라서 여러 테스트에서 1L의 ID값으로 데이터를 생성하는 코드를 작성했지만, 테스트 DB 내부에서는 2L, 3L 등으로 increment되어버리기 때문에 increment 처리된 테스트는 검증에 실패함
- 이 이슈를 해결하기 위해서 ID에 의존적이지 않은 DiaryRepositoryTest로 변경함

## 데이터베이스 변경
아래 sql 쿼리를 추가해주세요
```sql
ALTER TABLE diary ADD deleted_at datetime AFTER updated_at;
```

## 관련 이슈

close #57 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
