### PR TITLE
:sparkles: feature: 감정 목록 조회 API 언어 파라미터 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/controller/EmotionController.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.emotion.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
@@ -37,10 +39,15 @@ public class EmotionController {
     })
     @GetMapping("/all")
     public ResponseEntity<SuccessResponse<List<GetActiveEmotionsResponse>>> getAllEmotions(
-        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
+        @Parameter(description = "반환 언어(ko/en)", in = ParameterIn.QUERY)
+        @RequestParam(value = "lan", required = false, defaultValue = "ko") String language
     ) {
+        if (!language.matches("^(ko|en)$")) {
+            language = "ko";
+        }
         return SuccessResponse.of(
-            emotionService.getActiveEmotions(tokenInfo.getUserId())
+            emotionService.getActiveEmotions(tokenInfo.getUserId(), language)
         ).asHttp(HttpStatus.OK);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/emotion/dto/GetActiveEmotionsResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/dto/GetActiveEmotionsResponse.java
@@ -26,10 +26,20 @@ public class GetActiveEmotionsResponse {
         return new GetActiveEmotionsResponse(id, name, color);
     }
 
-    public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions) {
+    public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions,
+        String language) {
         return emotions.stream()
-            .map(e -> GetActiveEmotionsResponse.of(e.getEmotionId(), e.getName(), e.getColor()))
+            .map(e -> GetActiveEmotionsResponse.of(
+                e.getEmotionId(), getEmotionName(language, e), e.getColor()))
             .collect(
                 Collectors.toList());
+    }
+
+    private static String getEmotionName(String language, Emotion emotion) {
+        if (language.equals("ko")) {
+            return emotion.getName();
+        } else {
+            return emotion.getEmotionPrompt();
+        }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/service/EmotionService.java
@@ -20,10 +20,10 @@ public class EmotionService {
     private final ValidateUserService validateUserService;
 
 
-    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId) {
+    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId, String language) {
         validateUserService.validateUserById(userId);
         return GetActiveEmotionsResponse.buildWithEmotions(
-            emotionRepository.findAllActiveEmotions());
+            emotionRepository.findAllActiveEmotions(), language);
     }
 
     @Transactional

--- a/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/EmotionServiceTest.java
@@ -55,7 +55,7 @@ public class EmotionServiceTest {
                 given(validateUserService.validateUserById(1L)).willThrow(
                     new UserNotFoundException());
 
-                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L))
+                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L, "ko"))
                     .isInstanceOf(UserNotFoundException.class);
             }
         }
@@ -73,11 +73,31 @@ public class EmotionServiceTest {
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
 
-                List<GetActiveEmotionsResponse> emotions = emotionService.getActiveEmotions(1L);
+                List<GetActiveEmotionsResponse> emotions =
+                    emotionService.getActiveEmotions(1L, "ko");
 
                 assertThat(emotions.get(0).getId()).isEqualTo(activeEmotion.getEmotionId());
                 assertThat(emotions).extracting(GetActiveEmotionsResponse::getId)
                     .isNotEqualTo(inActiveEmotion.getEmotionId());
+            }
+        }
+
+        @Nested
+        @DisplayName("영어로 반환하도록 요청할 경우")
+        class if_language_for_english {
+
+            @Test
+            @DisplayName("감정 값을 영어로 반환한다.")
+            void it_returns_emotion_as_english() {
+                User user = createUserWithId(1L);
+                Emotion activeEmotion = createEmotion();
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+                given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
+
+                List<GetActiveEmotionsResponse> emotions =
+                    emotionService.getActiveEmotions(1L, "en");
+
+                assertThat(emotions.get(0).getName()).isEqualTo(activeEmotion.getEmotionPrompt());
             }
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[GET] emotions/all 감정 목록 조회 API
- `lan` query parameter를 추가해, 언어 설정을 요청받도록 했습니다.
- `ko`, `en` 값을 요청받을 수 있으며, 이 외의 값을 요청하거나 값을 전달하지 않았을 경우 `ko`로 처리됩니다.
- `en`을 요청 받을 경우, 영어로 반환하는 경우이므로 Emotion의 emotionPrompt 객체 값으로 반환됩니다.

## 관련 이슈

close #64 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
