### PR TITLE
RestClientException 발생시 GlobalExceptionHandler가 공통적인 예외로 핸들링하도록 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -55,7 +55,10 @@ public enum ErrorCode {
 
     // OAuth
     OAUTH_NOT_FOUND(404, "O001", "유저의 refresh token을 찾을 수 없습니다."),
-    OAUTH_SERVER_FAILED(500, "O002", "OAuth 서버와의 통신 중 에러가 발생하였습니다.");
+    OAUTH_SERVER_FAILED(500, "O002", "OAuth 서버와의 통신 중 에러가 발생하였습니다."),
+
+    // REST
+    REST_CLIENT_FAILED(500, "R001", "외부로의 REST 통신에 실패하였습니다.");
 
 
     private final int status;

--- a/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
@@ -93,7 +93,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(RestClientException.class)
     public ResponseEntity<Object> handleRestClientException(RestClientException e) {
         log.error("RestClientException", e);
-        return handleExceptionInternal(ErrorCode.OAUTH_SERVER_FAILED);
+        return handleExceptionInternal(ErrorCode.REST_CLIENT_FAILED);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {


### PR DESCRIPTION
# 구현 내용

## 구현 요약
GlobalExceptionHandler에서 RestClientException을 처리하는 handleRestClientException 메소드는 
기존에 OAUTH_SERVER_FAILED로 핸들링하였으나, 
DALL-E 요청에서도 RestClientException이 발생할수 있기 때문에, 공통적인 예외인 REST_CLIENT_FAILED로 핸들링하도록 수정함

아래 Conversation에서 이야기 나누었으나 누락되어 수정함
https://github.com/tipi-tapi/ai-paint-today-BE/pull/51#discussion_r1235007444

## 관련 이슈

close #67 
참고 #51 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
