### PR TITLE
서버 생존 검증 api 추가 및 테스트용 토큰 만료 api 테스트 도메인으로 이동

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/DrawMyTodayApplication.java
+++ b/src/main/java/tipitapi/drawmytoday/DrawMyTodayApplication.java
@@ -2,10 +2,16 @@ package tipitapi.drawmytoday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ComponentScan(
+    basePackages = {"tipitapi.drawmytoday"},
+    excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "tipitapi.drawmytoday.dev.*")
+)
 public class DrawMyTodayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/tipitapi/drawmytoday/common/config/DevConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/DevConfig.java
@@ -1,0 +1,12 @@
+package tipitapi.drawmytoday.common.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("!prod")
+@Configuration
+@ComponentScan(basePackages = {"tipitapi.drawmytoday.dev"})
+public class DevConfig {
+
+}

--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -87,12 +87,12 @@ public class SwaggerConfiguration {
     }
 
     @Bean
-    public GroupedOpenApi serverOpenAPi() {
-        String[] paths = {"/server/**"};
+    public GroupedOpenApi healthOpenAPi() {
+        String[] paths = {"/health/**"};
 
         return GroupedOpenApi
             .builder()
-            .group("서버 API")
+            .group("Health Check API")
             .pathsToMatch(paths)
             .build();
     }

--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -76,12 +76,23 @@ public class SwaggerConfiguration {
     }
 
     @Bean
-    public GroupedOpenApi testOpenAPi() {
-        String[] paths = {"/test/**"};
+    public GroupedOpenApi devOpenAPi() {
+        String[] paths = {"/dev/**"};
 
         return GroupedOpenApi
             .builder()
-            .group("테스트 API")
+            .group("개발 환경 API")
+            .pathsToMatch(paths)
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi serverOpenAPi() {
+        String[] paths = {"/server/**"};
+
+        return GroupedOpenApi
+            .builder()
+            .group("서버 API")
             .pathsToMatch(paths)
             .build();
     }

--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -74,4 +74,15 @@ public class SwaggerConfiguration {
             .pathsToMatch(paths)
             .build();
     }
+
+    @Bean
+    public GroupedOpenApi testOpenAPi() {
+        String[] paths = {"/test/**"};
+
+        return GroupedOpenApi
+            .builder()
+            .group("테스트 API")
+            .pathsToMatch(paths)
+            .build();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/dev/controller/DevelopController.java
+++ b/src/main/java/tipitapi/drawmytoday/dev/controller/DevelopController.java
@@ -1,4 +1,4 @@
-package tipitapi.drawmytoday.test.controller;
+package tipitapi.drawmytoday.dev.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,9 +16,9 @@ import tipitapi.drawmytoday.common.security.jwt.JwtType;
 import tipitapi.drawmytoday.common.utils.HeaderUtils;
 
 @RestController
-@RequestMapping("/test")
+@RequestMapping("/dev")
 @RequiredArgsConstructor
-public class TestController {
+public class DevelopController {
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -42,12 +41,5 @@ public class TestController {
     public String getExpiredJwt(HttpServletRequest request) {
         String jwtToken = HeaderUtils.getJwtToken(request, JwtType.BOTH);
         return jwtTokenProvider.expireToken(jwtToken);
-    }
-
-    @Operation(summary = "서버 생존 여부 체크용", description = "서버가 살아있는지 체크합니다.")
-    @ApiResponse(responseCode = "204", description = "서버 생존")
-    @GetMapping("/server")
-    public ResponseEntity<Void> verifyServerAlive() {
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
+++ b/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
@@ -8,12 +8,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/server")
+@RequestMapping("/health")
 public class HealthCheckController {
 
     @Operation(summary = "서버 생존 여부 체크용", description = "서버가 살아있는지 체크합니다.")
     @ApiResponse(responseCode = "204", description = "서버 생존")
-    @GetMapping("/alive")
+    @GetMapping("/server")
     public ResponseEntity<Void> verifyServerAlive() {
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
+++ b/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
@@ -1,0 +1,20 @@
+package tipitapi.drawmytoday.health.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/server")
+public class HealthCheckController {
+
+    @Operation(summary = "서버 생존 여부 체크용", description = "서버가 살아있는지 체크합니다.")
+    @ApiResponse(responseCode = "204", description = "서버 생존")
+    @GetMapping("/alive")
+    public ResponseEntity<Void> verifyServerAlive() {
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -135,26 +135,4 @@ public class AuthController {
         oAuthService.deleteAccount(tokenInfo.getUserId());
         return ResponseEntity.noContent().build();
     }
-
-    @Operation(summary = "토큰 만료(테스트)", description = "jwt token을 만료시킵니다.",
-        security = @SecurityRequirement(name = "Bearer Authentication"))
-    @ApiResponses(value = {
-        @ApiResponse(
-            responseCode = "200",
-            description = "jwt token 만료 성공"),
-        @ApiResponse(
-            responseCode = "400",
-            description = "S002 : 유효하지 않은 토큰입니다.",
-            content = @Content(schema = @Schema(hidden = true))),
-        @ApiResponse(
-            responseCode = "404",
-            description = "S008 : jwt token이 없습니다.",
-            content = @Content(schema = @Schema(hidden = true)))
-    })
-    @GetMapping("/expire")
-    public String getExpiredJwt(HttpServletRequest request) {
-        String jwtToken = HeaderUtils.getJwtToken(request, JwtType.BOTH);
-        return jwtTokenProvider.expireToken(jwtToken);
-    }
-
 }

--- a/src/main/java/tipitapi/drawmytoday/test/controller/TestController.java
+++ b/src/main/java/tipitapi/drawmytoday/test/controller/TestController.java
@@ -1,0 +1,53 @@
+package tipitapi.drawmytoday.test.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
+import tipitapi.drawmytoday.common.security.jwt.JwtType;
+import tipitapi.drawmytoday.common.utils.HeaderUtils;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "토큰 만료", description = "jwt token을 만료시킵니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "jwt token 만료 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "S002 : 유효하지 않은 토큰입니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "S008 : jwt token이 없습니다.",
+            content = @Content(schema = @Schema(hidden = true)))
+    })
+    @GetMapping("/expire")
+    public String getExpiredJwt(HttpServletRequest request) {
+        String jwtToken = HeaderUtils.getJwtToken(request, JwtType.BOTH);
+        return jwtTokenProvider.expireToken(jwtToken);
+    }
+
+    @Operation(summary = "서버 생존 여부 체크용", description = "서버가 살아있는지 체크합니다.")
+    @ApiResponse(responseCode = "204", description = "서버 생존")
+    @GetMapping("/server")
+    public ResponseEntity<Void> verifyServerAlive() {
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- health 도메인에 서버 생존 검증 api 추가
- 토큰 만료 api를 기존 auth 도메인에서 dev 도메인으로 이동
- dev 도메인은 prod 프로필일 경우 컴포넌트 스캔 대상에서 제외하도록 설정

## 관련 이슈

close #69 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
