### PR TITLE
월별 일기 조회 API가 반환하는 이미지 URL을 FULL 이미지 URL로 반환하도록 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import tipitapi.drawmytoday.diary.domain.Diary;
 
 @Getter
 @Schema(description = "월별 일기 목록 Response")
@@ -29,9 +28,8 @@ public class GetMonthlyDiariesResponse {
     @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
     private final LocalDateTime date;
 
-    public static GetMonthlyDiariesResponse of(Diary diary) {
-        return new GetMonthlyDiariesResponse(diary.getDiaryId(),
-            diary.getImageList().get(0).getImageUrl(),
-            diary.getDiaryDate());
+    public static GetMonthlyDiariesResponse of(Long diaryId, String imageUrl,
+        LocalDateTime diaryDate) {
+        return new GetMonthlyDiariesResponse(diaryId, imageUrl, diaryDate);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -87,7 +87,12 @@ public class DiaryService {
                 }
                 return true;
             })
-            .map(GetMonthlyDiariesResponse::of)
+            .map(diary -> {
+                String imageUrl = s3PreSignedService.getPreSignedUrlForShare(
+                    diary.getImageList().get(0).getImageUrl(), 30);
+                return GetMonthlyDiariesResponse.of(diary.getDiaryId(), imageUrl,
+                    diary.getDiaryDate());
+            })
             .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [GET] /diary/calendar/monthly 월별 일기 조회 API
  - 기존에는 이미지 URI만 반환함
  - Presigned URL 처리가 된 Full Image Url로 반환하도록 수정함

## 관련 이슈

close #77 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
