### PR TITLE
 User 엔티티에 Soft delete 애노테이션 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -13,11 +13,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = current_timestamp WHERE diary_id = ?")
+@Where(clause = "deleted_at is null")
 public class User extends BaseEntityWithUpdate {
 
     @Id

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -13,14 +13,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE user SET deleted_at = current_timestamp WHERE diary_id = ?")
 @Where(clause = "deleted_at is null")
 public class User extends BaseEntityWithUpdate {
 

--- a/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/user/repository/UserRepository.java
@@ -7,7 +7,7 @@ import tipitapi.drawmytoday.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
+    Optional<User> findByUserId(Long userId);
 
     List<User> findAllByEmail(String email);
 }

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -19,13 +19,13 @@ public class ValidateUserService {
     private final UserRepository userRepository;
 
     public User validateUserById(Long userId) {
-        return userRepository.findByUserIdAndDeletedAtIsNull(userId)
+        return userRepository.findByUserId(userId)
             .orElseThrow(UserNotFoundException::new);
     }
 
     public User validateRegisteredUserByEmail(String email, SocialCode socialCode) {
         return userRepository.findAllByEmail(email).stream()
-            .filter(user -> user.getDeletedAt() == null && user.getSocialCode() == socialCode)
+            .filter(user -> user.getSocialCode() == socialCode)
             .findFirst()
             .orElse(null);
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -10,6 +11,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import tipitapi.drawmytoday.common.BaseRepositoryTest;
+import tipitapi.drawmytoday.common.testdata.TestUser;
+import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 
 @DataJpaTest
@@ -18,7 +21,7 @@ public class UserRepositoryTest extends BaseRepositoryTest {
 
     @Nested
     @DisplayName("findByUserId 메소드 테스트")
-    class findByUserIdTest {
+    class FindByUserIdTest {
 
         @Nested
         @DisplayName("유저가 존재하는 경우")
@@ -33,6 +36,102 @@ public class UserRepositoryTest extends BaseRepositoryTest {
 
                 assertThat(findUser.isPresent()).isTrue();
                 assertThat(findUser.get().getUserId()).isEqualTo(user.getUserId());
+            }
+        }
+
+        @Nested
+        @DisplayName("삭제된 유저가 존재할 경우")
+        class If_deleted_user_exists {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                User user = TestUser.createUser();
+                user.deleteUser();
+                userRepository.save(user);
+
+                Optional<User> findUser = userRepository.findByUserId(user.getUserId());
+
+                assertThat(findUser).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("유저가 존재하지 않는 경우")
+        class If_user_not_exist {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                Long notExistUserId = 1L;
+
+                Optional<User> findUser = userRepository.findByUserId(notExistUserId);
+
+                assertThat(findUser).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByEmail 메서드 테스트")
+    class FindAllByEmailTest {
+
+        private final String email = "example@email.com";
+        private final String otherEmail = "aaaa@email.com";
+
+        @Nested
+        @DisplayName("이메일에 해당하는 유저가 2명일 경우")
+        class If_two_user_exists {
+
+            @Test
+            @DisplayName("두 유저를 반환한다.")
+            void return_two_user_list() {
+                User googleUser = User.createWithEmail(email, SocialCode.GOOGLE);
+                User appleUser = User.createWithEmail(email, SocialCode.APPLE);
+                User otherUser = User.createWithEmail(otherEmail, SocialCode.GOOGLE);
+                userRepository.save(googleUser);
+                userRepository.save(appleUser);
+                userRepository.save(otherUser);
+
+                List<User> findUserList = userRepository.findAllByEmail(email);
+
+                assertThat(findUserList).containsExactlyInAnyOrder(googleUser, appleUser);
+                assertThat(findUserList).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("이메일에 해당하는 유저가 한 명일 경우")
+        class If_one_user_exists {
+
+            @Test
+            @DisplayName("유저를 반환한다.")
+            void return_one_user_list() {
+                User googleUser = User.createWithEmail(email, SocialCode.GOOGLE);
+                User otherUser = User.createWithEmail(otherEmail, SocialCode.GOOGLE);
+                userRepository.save(googleUser);
+                userRepository.save(otherUser);
+
+                List<User> findUserList = userRepository.findAllByEmail(email);
+
+                assertThat(findUserList).containsExactly(googleUser);
+                assertThat(findUserList).hasSize(1);
+            }
+        }
+
+        @Nested
+        @DisplayName("이메일에 해당하는 유저가 없을 경우")
+        class If_user_not_exists {
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다.")
+            void return_empty_list() {
+                User otherUser = User.createWithEmail(otherEmail, SocialCode.GOOGLE);
+                userRepository.save(otherUser);
+                
+                List<User> findUserList = userRepository.findAllByEmail(email);
+
+                assertThat(findUserList).isEmpty();
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
@@ -86,12 +86,11 @@ public class UserRepositoryTest extends BaseRepositoryTest {
             @Test
             @DisplayName("두 유저를 반환한다.")
             void return_two_user_list() {
-                User googleUser = User.createWithEmail(email, SocialCode.GOOGLE);
-                User appleUser = User.createWithEmail(email, SocialCode.APPLE);
-                User otherUser = User.createWithEmail(otherEmail, SocialCode.GOOGLE);
-                userRepository.save(googleUser);
-                userRepository.save(appleUser);
-                userRepository.save(otherUser);
+                User googleUser = userRepository.save(
+                    User.createWithEmail(email, SocialCode.GOOGLE));
+                User appleUser = userRepository.save(User.createWithEmail(email, SocialCode.APPLE));
+                User otherUser = userRepository.save(
+                    User.createWithEmail(otherEmail, SocialCode.GOOGLE));
 
                 List<User> findUserList = userRepository.findAllByEmail(email);
 
@@ -128,7 +127,7 @@ public class UserRepositoryTest extends BaseRepositoryTest {
             void return_empty_list() {
                 User otherUser = User.createWithEmail(otherEmail, SocialCode.GOOGLE);
                 userRepository.save(otherUser);
-                
+
                 List<User> findUserList = userRepository.findAllByEmail(email);
 
                 assertThat(findUserList).isEmpty();

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/UserRepositoryTest.java
@@ -1,0 +1,40 @@
+package tipitapi.drawmytoday.diary.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import tipitapi.drawmytoday.common.BaseRepositoryTest;
+import tipitapi.drawmytoday.user.domain.User;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class UserRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    @DisplayName("findByUserId 메소드 테스트")
+    class findByUserIdTest {
+
+        @Nested
+        @DisplayName("유저가 존재하는 경우")
+        class If_user_exists {
+
+            @Test
+            @DisplayName("유저를 반환한다.")
+            void return_user() {
+                User user = createUser();
+
+                Optional<User> findUser = userRepository.findByUserId(user.getUserId());
+
+                assertThat(findUser.isPresent()).isTrue();
+                assertThat(findUser.get().getUserId()).isEqualTo(user.getUserId());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- User 엔티티에 @Where 애노테이션 적용
- 앞에 두 애노테이션 추가에 따른 UserRepository, UserService 로직 수정
- UserRepository 메서드들 테스트 검증 로직 추가

__@SQLDelete도 추가하고 싶었지만 user 테이블이 SQL 키워드이기에 identifier 에러가 떠서.. 그냥 deleteAt을 update하여 삭제하는 방식 그대로 가겠습니다.__
## 관련 이슈

close #62 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
