### PR TITLE
테스트 환경 Gradle로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,8 @@ dependencies {
 }
 
 tasks.named('test') {
-//	useJUnitPlatform()
+    useJUnitPlatform()
 }
-
 jar {
     enabled = false
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+    profiles:
+        include: oauth, aws, openai
     datasource:
         driver-class-name: org.h2.Driver
         url: jdbc:h2:mem:draw_my_today_db;MODE=MySQL;


### PR DESCRIPTION
# 구현 내용

ci 서버에서 테스트한 환경이랑 동일하게 맞추기 위해 테스트 환경을 인텔리제이가 아닌 Gradle로 돌리도록 바꾸었습니다. 다만 Gradle로 테스트를 돌릴 시 테스트 속도가 느리다는 단점이 있습니다 ^^;

설정 방법은 다음과 같습니다.

1. Preferences -> Build, Execution, Deployment -> Build Tools -> Gradle에서 Build and Run을 둘 다 Gradle로 변경합니다.
<img width="700" alt="image" src="https://github.com/tipi-tapi/ai-paint-today-BE/assets/39454230/b98b292a-936c-4f27-bf3b-f0b86c0ecd00">

2. Run/Debug Configurations -> Edit configuration templates -> Gradle에서 Environment variables를 설정합니다.
<img width="700" alt="image" src="https://github.com/tipi-tapi/ai-paint-today-BE/assets/39454230/dad77f85-98ac-4a4a-a33b-7cc10669e35e">

3. 테스트를 실행하면 Gradle 템플릿에 적용한 환경변수가 등록되어 테스트가 동작합니다.

## 관련 이슈

close #82 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

