### PR TITLE
에러 코드에 이름이 넘어가는 문제 해결 및 일기 생성 제한 해제

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
@@ -113,7 +113,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-            .code(errorCode.name())
+            .code(errorCode.getCode())
             .message(errorCode.getMessage())
             .build();
     }

--- a/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/tipitapi/drawmytoday/common/security/jwt/JwtAuthenticationEntryPoint.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationEntryPoint extends OncePerRequestFilter {
 
     private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
         return ErrorResponse.builder()
-            .code(errorCode.name())
+            .code(errorCode.getCode())
             .message(errorCode.getMessage())
             .build();
     }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -39,7 +39,8 @@ public class CreateDiaryService {
     public CreateDiaryResponse createDiary(Long userId, Long emotionId, String keyword,
         String notes) throws DallERequestFailException, ImageInputStreamFailException {
         // TODO: 이미지 여러 개로 요청할 경우의 핸들링 필요
-        User user = validateUserService.validateUserWithDrawLimit(userId);
+        // TODO: 광고 추가시 일기 생성 제한 로직으로 변경 필요
+        User user = validateUserService.validateUserById(userId);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
         String prompt = promptTextService.createPromptText(emotion, keyword);
         String encryptedNotes = encryptor.encrypt(notes);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- Error Response시 Error code가 아닌 Error name이 반환되는 문제 해결
- 일기 생성시 하루에 여러번 생성 가능하도록 변경(광고 도입 후 다시 막을 예정)

## 관련 이슈

close #91

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
