### PR TITLE
health check api 및 swagger 에러 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
         "/oauth2/google/login",
         "/oauth2/apple/login",
         "/oauth2/refresh",
-        "/oauth2/expiredJwt"
+        "/oauth2/expiredJwt",
+        "/health/server"
     };
 
     @Bean

--- a/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
+++ b/src/main/java/tipitapi/drawmytoday/health/controller/HealthCheckController.java
@@ -3,8 +3,8 @@ package tipitapi.drawmytoday.health.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,7 +13,7 @@ public class HealthCheckController {
 
     @Operation(summary = "서버 생존 여부 체크용", description = "서버가 살아있는지 체크합니다.")
     @ApiResponse(responseCode = "204", description = "서버 생존")
-    @GetMapping("/server")
+    @RequestMapping(value = "/server", method = RequestMethod.HEAD)
     public ResponseEntity<Void> verifyServerAlive() {
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
+import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
 import tipitapi.drawmytoday.common.security.jwt.JwtType;
@@ -59,8 +61,11 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping(value = "/google/login")
-    public ResponseJwtToken googleLogin(HttpServletRequest request) throws JsonProcessingException {
-        return googleOAuthService.login(request);
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleLogin(HttpServletRequest request)
+        throws JsonProcessingException {
+        return SuccessResponse.of(
+            googleOAuthService.login(request)
+        ).asHttp(HttpStatus.OK);
     }
 
     @Operation(summary = "애플 로그인", description = "프론트로부터 Authorization code, idToken을 받아 애플 로그인을 진행합니다.")
@@ -82,10 +87,11 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping(value = "/apple/login")
-    public ResponseJwtToken appleLogin(HttpServletRequest request,
-        @RequestBody @Valid RequestAppleLogin requestAppleLogin)
-        throws IOException {
-        return appleOAuthService.login(request, requestAppleLogin);
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> appleLogin(HttpServletRequest request,
+        @RequestBody @Valid RequestAppleLogin requestAppleLogin) throws IOException {
+        return SuccessResponse.of(
+            appleOAuthService.login(request, requestAppleLogin)
+        ).asHttp(HttpStatus.OK);
     }
 
     @Operation(summary = "jwt access token 재발급",
@@ -102,11 +108,14 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/refresh")
-    public ResponseAccessToken getAccessToken(HttpServletRequest request) {
+    public ResponseEntity<SuccessResponse<ResponseAccessToken>> getAccessToken(
+        HttpServletRequest request) {
         String refreshToken = HeaderUtils.getJwtToken(request, JwtType.REFRESH);
         jwtTokenProvider.validRefreshToken(refreshToken);
         String accessToken = jwtTokenProvider.createNewAccessTokenFromRefreshToken(refreshToken);
-        return ResponseAccessToken.of(accessToken);
+        return SuccessResponse.of(
+            ResponseAccessToken.of(accessToken)
+        ).asHttp(HttpStatus.OK);
     }
 
     @Operation(summary = "회원 탈퇴", description = "소셜로그인 탈퇴를 진행하고, 회원을 deleted 상태로 변경합니다.",

--- a/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/controller/AuthController.java
@@ -11,14 +11,12 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
@@ -61,7 +59,6 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping(value = "/google/login")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseJwtToken googleLogin(HttpServletRequest request) throws JsonProcessingException {
         return googleOAuthService.login(request);
     }
@@ -85,7 +82,6 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping(value = "/apple/login")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseJwtToken appleLogin(HttpServletRequest request,
         @RequestBody @Valid RequestAppleLogin requestAppleLogin)
         throws IOException {
@@ -130,7 +126,6 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @DeleteMapping("/users")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<Void> deleteAccount(@AuthUser JwtTokenInfo tokenInfo) {
         oAuthService.deleteAccount(tokenInfo.getUserId());
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- health check api를 토큰 없이 호출 가능하도록 수정
- health check api의 http method를 GET -> HEAD 변경(GET보다 더 가볍고 빠름)
- swagger에 명세된 회원 탈퇴 api의 성공 응답 코드가 204만 존재하도록 변경
- AuthController의 구글 로그인, 애플 로그인, jwt access token 재발급 api의 response 타입을 ResponseEntity<SuccessResponse<~~>>로 변경(response type을 통일했어야 했는데 그대로 반환하고 있었기에 변경했습니다. 프론트에게도 해당 이슈를 전달해 바뀐 response에 맞게 수정하도록 하겠습니다)

## 관련 이슈

close #95 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
