### PR TITLE
http response시 빈 배열일 경우 빈 배열을 반환하도록 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/response/SuccessResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/common/response/SuccessResponse.java
@@ -1,6 +1,7 @@
 package tipitapi.drawmytoday.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +17,7 @@ public class SuccessResponse<T> {
     @Schema(description = "성공 여부. 항상 true 이다.", defaultValue = "true")
     private final boolean status = true;
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(Include.NON_NULL)
     private T data;
 
     public static <T> SuccessResponse<T> of(T data) {

--- a/src/test/java/tipitapi/drawmytoday/response/SuccessResponseTest.java
+++ b/src/test/java/tipitapi/drawmytoday/response/SuccessResponseTest.java
@@ -1,0 +1,67 @@
+package tipitapi.drawmytoday.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tipitapi.drawmytoday.common.response.SuccessResponse;
+
+@DisplayName("SuccessResponse 클래스는")
+public class SuccessResponseTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeAll
+    static void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Nested
+    @DisplayName("data값이")
+    class If_data_is {
+
+        @Test
+        @DisplayName("null이 아니면 data 키를 생성한다.")
+        void if_data_not_null_than_data_key() throws Exception {
+            // given
+            SuccessResponse<String> successResponse = SuccessResponse.of("data");
+
+            // when
+            String json = objectMapper.writeValueAsString(successResponse);
+
+            // then
+            assertThat(json).contains('"' + "data" + '"' + ":" + '"' + "data" + '"');
+        }
+
+        @Test
+        @DisplayName("빈 리스트이면 data에 빈 배열을 반환한다.")
+        void if_data_is_empty_list_than_empty_array() throws Exception {
+            // given
+            SuccessResponse<List<String>> successResponse = SuccessResponse.of(List.of());
+
+            // when
+            String json = objectMapper.writeValueAsString(successResponse);
+
+            // then
+            assertThat(json).contains('"' + "data" + '"' + ":[]");
+        }
+
+        @Test
+        @DisplayName("null이면 data 키를 생성하지 않는다.")
+        void if_data_null_than_no_data_key() throws Exception {
+            // given
+            SuccessResponse<String> successResponse = SuccessResponse.of(null);
+
+            // when
+            String json = objectMapper.writeValueAsString(successResponse);
+
+            // then
+            assertThat(json).doesNotContain('"' + "data" + '"' + ":");
+        }
+    }
+
+}

--- a/src/test/java/tipitapi/drawmytoday/response/SuccessResponseTest.java
+++ b/src/test/java/tipitapi/drawmytoday/response/SuccessResponseTest.java
@@ -34,7 +34,7 @@ public class SuccessResponseTest {
             String json = objectMapper.writeValueAsString(successResponse);
 
             // then
-            assertThat(json).contains('"' + "data" + '"' + ":" + '"' + "data" + '"');
+            assertThat(json).contains("\"data\":\"data\"");
         }
 
         @Test
@@ -47,7 +47,7 @@ public class SuccessResponseTest {
             String json = objectMapper.writeValueAsString(successResponse);
 
             // then
-            assertThat(json).contains('"' + "data" + '"' + ":[]");
+            assertThat(json).contains("\"data\":[]");
         }
 
         @Test
@@ -60,7 +60,7 @@ public class SuccessResponseTest {
             String json = objectMapper.writeValueAsString(successResponse);
 
             // then
-            assertThat(json).doesNotContain('"' + "data" + '"' + ":");
+            assertThat(json).doesNotContain("\"data\":");
         }
     }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- SuccessResponse에서 data를 파싱할 때 값이 빈 비열이면 빈 배열이 반환되도록 변경
- SuccessResponse 테스트코드 작성(원래는 컨트롤러 메서드에 직접 넣어 테스트환경을 구축하려 했으나 시간이 많이 걸릴것 같아 objectMapper를 사용하여 파싱하는 방향으로 바꿨습니다)

## 관련 이슈

close #97

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
