### PR TITLE
테스트용 SQL 파일에서 AdType 삭제

### DIFF
--- a/src/test/resources/tipitapi/drawmytoday/adreward/repository/ExpiredAdReward.sql
+++ b/src/test/resources/tipitapi/drawmytoday/adreward/repository/ExpiredAdReward.sql
@@ -2,7 +2,7 @@ INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_dia
                     social_code, user_role)
 VALUES (1, '2023-03-01T15:20:02.236278', '2023-03-01T15:20:02.236278', null, null, null, 'GOOGLE',
         null);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (1, '2023-04-01T09:20:02.236278', 'VIDEO', null, 1);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (2, '2023-06-30T08:20:02.236278', 'VIDEO', '2023-07-01T04:20:02.012345', 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (1, '2023-04-01T09:20:02.236278', null, 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (2, '2023-06-30T08:20:02.236278', '2023-07-01T04:20:02.012345', 1);

--- a/src/test/resources/tipitapi/drawmytoday/adreward/repository/ValidAdReward.sql
+++ b/src/test/resources/tipitapi/drawmytoday/adreward/repository/ValidAdReward.sql
@@ -3,11 +3,11 @@ INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_dia
                     user_role)
 VALUES (1, '2023-03-01T15:20:02.236278', '2023-03-01T15:20:02.236278', null, null, null, 'GOOGLE',
         null);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (1, '2023-04-01T15:38:02.012342', 'VIDEO', null, 1);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (2, '2023-05-03T15:10:02.354232', 'VIDEO', '2023-05-04T15:20:02.235513', 1);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (3, '2023-06-20T09:29:02.534499', 'VIDEO', null, 1);
-INSERT INTO `ad_reward` (ad_reward_id, created_at, ad_type, used_at, user_id)
-VALUES (4, '2023-06-28T13:00:02.236278', 'VIDEO', null, 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (1, '2023-04-01T15:38:02.012342', null, 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (2, '2023-05-03T15:10:02.354232', '2023-05-04T15:20:02.235513', 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (3, '2023-06-20T09:29:02.534499', null, 1);
+INSERT INTO `ad_reward` (ad_reward_id, created_at, used_at, user_id)
+VALUES (4, '2023-06-28T13:00:02.236278', null, 1);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

기존에 광고 리워드 도메인을 작업하면서, 광고의 유형을 나타낸 AdType 엔티티가 작업 도중 사라졌으나, 테스트용 SQL 파일에서 삭제되지 않았기에, 이를 삭제하였습니다.

## 관련 이슈

close #100 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
