### PR TITLE
일기 생성시, 테스트 용으로 생성할 수 있는 기능 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -134,11 +134,13 @@ public class DiaryController {
     @PostMapping()
     public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createDiary(
         @RequestBody @Valid CreateDiaryRequest createDiaryRequest,
-        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
+        @Parameter(description = "테스트 여부", in = ParameterIn.QUERY)
+        @RequestParam(value = "test", required = false, defaultValue = "false") boolean test
     ) throws DallERequestFailException, ImageInputStreamFailException {
         return SuccessResponse.of(
             createDiaryService.createDiary(tokenInfo.getUserId(), createDiaryRequest.getEmotionId(),
-                createDiaryRequest.getKeyword(), createDiaryRequest.getNotes())
+                createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(), test)
         ).asHttp(HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[POST] /diary 일기 생성 API
- 일기 생성시 `test`라는 query parameter가 true 값으로 주어질 경우, dummy 일기로 생성함
- dall-e에 요청하여 이미지를 생성하지 않고, s3에 새로운 이미지를 게시하지 않음
- s3에 미리 등록해둔 테스트용 이미지의 URI로 Image 객체가 생성됨 ( s3://bucket-8th-team4/test/dummy.png )

## 관련 이슈

close #106 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
