### PR TITLE
광고 리워드 유효 시간 변경, 일기 생성 가능 여부 조회 API 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/adreward/service/UseAdRewardService.java
+++ b/src/main/java/tipitapi/drawmytoday/adreward/service/UseAdRewardService.java
@@ -19,7 +19,7 @@ public class UseAdRewardService {
     @Transactional
     public boolean useReward(User user) {
         LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusWeeks(1);
+        LocalDateTime startDate = endDate.minusHours(1);
         List<AdReward> adReward = adRewardRepository.findValidAdReward(user.getUserId(),
             startDate, endDate);
         if (adReward.isEmpty()) {

--- a/src/main/java/tipitapi/drawmytoday/adreward/service/UseAdRewardService.java
+++ b/src/main/java/tipitapi/drawmytoday/adreward/service/UseAdRewardService.java
@@ -1,31 +1,25 @@
 package tipitapi.drawmytoday.adreward.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.adreward.domain.AdReward;
-import tipitapi.drawmytoday.adreward.repository.AdRewardRepository;
-import tipitapi.drawmytoday.user.domain.User;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UseAdRewardService {
 
-    private final AdRewardRepository adRewardRepository;
+    private final ValidateAdRewardService validateAdRewardService;
 
     @Transactional
-    public boolean useReward(User user) {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusHours(1);
-        List<AdReward> adReward = adRewardRepository.findValidAdReward(user.getUserId(),
-            startDate, endDate);
+    public boolean useReward(Long userId) {
+        Optional<AdReward> adReward = validateAdRewardService.findValidAdReward(userId);
         if (adReward.isEmpty()) {
             return false;
         }
-        adReward.get(0).useReward();
+        adReward.get().useReward();
         return true;
     }
 

--- a/src/main/java/tipitapi/drawmytoday/adreward/service/ValidateAdRewardService.java
+++ b/src/main/java/tipitapi/drawmytoday/adreward/service/ValidateAdRewardService.java
@@ -1,0 +1,28 @@
+package tipitapi.drawmytoday.adreward.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.adreward.domain.AdReward;
+import tipitapi.drawmytoday.adreward.repository.AdRewardRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ValidateAdRewardService {
+
+    private final AdRewardRepository adRewardRepository;
+
+    public Optional<AdReward> findValidAdReward(Long userId) {
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusHours(1);
+        List<AdReward> adReward = adRewardRepository.findValidAdReward(userId, startDate, endDate);
+        if (adReward.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(adReward.get(0));
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -29,6 +29,7 @@ import tipitapi.drawmytoday.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.dalle.exception.ImageInputStreamFailException;
 import tipitapi.drawmytoday.diary.dto.CreateDiaryRequest;
 import tipitapi.drawmytoday.diary.dto.CreateDiaryResponse;
+import tipitapi.drawmytoday.diary.dto.GetDiaryLimitResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
@@ -188,5 +189,20 @@ public class DiaryController {
     ) {
         diaryService.deleteDiary(tokenInfo.getUserId(), diaryId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "일기 생성 가능 여부 조회", description = "유저가 금일 일기를 생성할 수 있는지 여부를 반환한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "일기 생성 가능 정보"),
+    })
+    @GetMapping("/limit")
+    public ResponseEntity<SuccessResponse<GetDiaryLimitResponse>> getDrawLimit(
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        return SuccessResponse.of(
+            diaryService.getDrawLimit(tokenInfo.getUserId())
+        ).asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryLimitResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryLimitResponse.java
@@ -1,0 +1,38 @@
+package tipitapi.drawmytoday.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "일기 생성 가능 여부 Response")
+@AllArgsConstructor
+public class GetDiaryLimitResponse {
+
+    @Schema(description = "일기 생성 가능 여부", requiredMode = RequiredMode.REQUIRED)
+    private final boolean available;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "마지막 일기 작성 시간", requiredMode = RequiredMode.NOT_REQUIRED)
+    private final LocalDateTime lastDiaryCreatedAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "유효 리워드 생성일자", requiredMode = RequiredMode.NOT_REQUIRED)
+    private LocalDateTime rewardCreatedAt;
+
+    public static GetDiaryLimitResponse of(boolean available, LocalDateTime lastDiaryCreatedAt,
+        LocalDateTime rewardCreatedAt) {
+        return new GetDiaryLimitResponse(available, lastDiaryCreatedAt, rewardCreatedAt);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.user.domain;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -69,5 +70,10 @@ public class User extends BaseEntityWithUpdate {
 
     public void deleteUser() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean checkDrawLimit() {
+        return this.getLastDiaryDate() == null
+            || !this.getLastDiaryDate().toLocalDate().equals(LocalDate.now());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.user.service;
 
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,15 +33,13 @@ public class ValidateUserService {
 
     public User validateUserWithDrawLimit(Long userId) {
         User user = validateUserById(userId);
-        if (user.getLastDiaryDate() == null) {
+        if (user.checkDrawLimit()) {
             return user;
-        } else if (user.getLastDiaryDate().toLocalDate().equals(LocalDate.now())) {
-            if (useAdRewardService.useReward(user)) {
+        } else {
+            if (useAdRewardService.useReward(userId)) {
                 return user;
             }
             throw new BusinessException(ErrorCode.USER_ALREADY_DRAW_DIARY);
-        } else {
-            return user;
         }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/adreward/service/ValidateAdRewardServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/adreward/service/ValidateAdRewardServiceTest.java
@@ -1,10 +1,13 @@
 package tipitapi.drawmytoday.adreward.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,33 +17,34 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.adreward.domain.AdReward;
+import tipitapi.drawmytoday.adreward.repository.AdRewardRepository;
 import tipitapi.drawmytoday.user.domain.User;
 
 @ExtendWith(MockitoExtension.class)
-class UseAdRewardServiceTest {
+class ValidateAdRewardServiceTest {
 
     @Mock
-    ValidateAdRewardService validateAdRewardService;
+    AdRewardRepository adRewardRepository;
     @InjectMocks
-    UseAdRewardService useAdRewardService;
+    ValidateAdRewardService validateAdRewardService;
 
     @Nested
-    @DisplayName("useReward 메소드 테스트")
-    class UseRewardTest {
+    @DisplayName("findValidAdReward 메소드 테스트")
+    class FindValidateAdRewardTest {
 
         @Nested
         @DisplayName("유효한 광고리워드가 존재하지 않을 경우")
         class If_no_valid_ad_reward_exists {
 
             @Test
-            @DisplayName("false를 반환한다.")
-            void return_false() {
-                given(validateAdRewardService.findValidAdReward(anyLong()))
-                    .willReturn(Optional.empty());
+            @DisplayName("null를 반환한다.")
+            void return_null() {
+                given(adRewardRepository.findValidAdReward(anyLong(), any(), any()))
+                    .willReturn(new ArrayList<>());
 
-                boolean used = useAdRewardService.useReward(1L);
+                Optional<AdReward> adReward = validateAdRewardService.findValidAdReward(1L);
 
-                assertThat(used).isFalse();
+                assertThat(adReward).isEmpty();
             }
         }
 
@@ -50,15 +54,16 @@ class UseAdRewardServiceTest {
 
             @Test
             @DisplayName("true를 반환한다.")
-            void return_true() {
+            void return_adreward() {
                 User user = createUserWithId(1L);
                 AdReward adReward = new AdReward(user);
-                given(validateAdRewardService.findValidAdReward(anyLong()))
-                    .willReturn(Optional.of(adReward));
+                given(adRewardRepository.findValidAdReward(anyLong(), any(), any()))
+                    .willReturn(List.of(adReward));
 
-                boolean used = useAdRewardService.useReward(1L);
+                Optional<AdReward> result = validateAdRewardService.findValidAdReward(1L);
 
-                assertThat(used).isTrue();
+                assertThat(result).isPresent();
+                assertThat(result.get().getAdRewardId()).isEqualTo(adReward.getAdRewardId());
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -25,10 +25,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import tipitapi.drawmytoday.adreward.domain.AdReward;
+import tipitapi.drawmytoday.adreward.service.ValidateAdRewardService;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
+import tipitapi.drawmytoday.diary.dto.GetDiaryLimitResponse;
 import tipitapi.drawmytoday.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.diary.dto.GetMonthlyDiariesResponse;
@@ -58,6 +62,8 @@ class DiaryServiceTest {
     Encryptor encryptor;
     @Mock
     PromptService promptService;
+    @Mock
+    ValidateAdRewardService validateAdRewardService;
     @InjectMocks
     DiaryService diaryService;
 
@@ -388,6 +394,120 @@ class DiaryServiceTest {
 
                 assertThatThrownBy(() -> diaryService.deleteDiary(1L, 1L))
                     .isInstanceOf(DiaryNotFoundException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getDrawLimit 메소드 테스트")
+    class GetDrawLimitTest {
+
+        @Nested
+        @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
+        class if_user_not_exists {
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 발생시킨다.")
+            void it_throws_UserNotFoundException() {
+                given(validateUserService.validateUserById(1L)).willThrow(
+                    new UserNotFoundException());
+
+                assertThatThrownBy(() -> diaryService.getDrawLimit(1L))
+                    .isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("user가 일기를 작성한 적이 없을 경우")
+        class if_user_never_wrote_diary {
+
+            @Test
+            @DisplayName("일기 생성 가능한 내용의 GetDrawLimitResponse 객체를 반환한다.")
+            void it_returns_available() {
+                User user = createUserWithId(1L);
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+
+                GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
+
+                assertThat(response.isAvailable()).isTrue();
+                assertThat(response.getLastDiaryCreatedAt()).isNull();
+                assertThat(response.getRewardCreatedAt()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("user가 오늘 작성한 일기가 없을 경우")
+        class if_user_didnt_write_diary_today {
+
+            @Test
+            @DisplayName("일기 생성 가능한 내용의 GetDrawLimitResponse 객체를 반환한다.")
+            void it_returns_available() {
+                User user = createUser();
+                LocalDateTime lastDiaryDate = LocalDateTime.now().minusDays(1);
+                user.setLastDiaryDate(lastDiaryDate);
+
+                given(validateUserService.validateUserById(1L)).willReturn(user);
+
+                GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
+
+                assertThat(response.isAvailable()).isTrue();
+                assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
+                assertThat(response.getRewardCreatedAt()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("user가 오늘 작성한 일기가 있을 경우")
+        class if_user_wrote_diary_today {
+
+            @Nested
+            @DisplayName("유효한 리워드가 있을 경우")
+            class if_valid_reward_exists {
+
+                @Test
+                @DisplayName("일기 생성 가능한 내용의 GetDrawLimitResponse 객체를 반환한다.")
+                void it_returns_available() {
+                    User user = createUser();
+                    LocalDateTime lastDiaryDate = LocalDateTime.now().minusMinutes(10);
+                    user.setLastDiaryDate(lastDiaryDate);
+
+                    AdReward adReward = new AdReward(user);
+                    LocalDateTime rewardCreatedAt = LocalDateTime.now().minusMinutes(30);
+                    ReflectionTestUtils.setField(adReward, "createdAt", rewardCreatedAt);
+
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(validateAdRewardService.findValidAdReward(1L)).willReturn(
+                        Optional.of(adReward));
+
+                    GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
+
+                    assertThat(response.isAvailable()).isTrue();
+                    assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
+                    assertThat(response.getRewardCreatedAt()).isEqualTo(rewardCreatedAt);
+                }
+            }
+
+            @Nested
+            @DisplayName("유효한 리워드가 없을 경우")
+            class if_valid_reward_not_exists {
+
+                @Test
+                @DisplayName("일기 생성 불가한 내용의 GetDrawLimitResponse 객체를 반환한다.")
+                void it_returns_unavailable() {
+                    User user = createUserWithId(1L);
+                    LocalDateTime lastDiaryDate = LocalDateTime.now();
+                    ReflectionTestUtils.setField(user, "lastDiaryDate", lastDiaryDate);
+
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(validateAdRewardService.findValidAdReward(1L)).willReturn(
+                        Optional.empty());
+
+                    GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
+
+                    assertThat(response.isAvailable()).isFalse();
+                    assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
+                    assertThat(response.getRewardCreatedAt()).isNull();
+                }
             }
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 광고 리워드의 유효 시간을 1시간으로 변경

- [GET] /diary/limit 일기 생성 가능 여부 조회 API
  - 금일 유저가 이미 일기를 생성했다면, available = false, 마지막 일기 생성 일자를 반환한다.
  - 하지만, 유저가 유효한 리워드가 있다면 available = true, 리워드 생성 일자를 반환한다.
  - 리워드와 관계 없이, 유저가 금일 생성한 일기가 없다면, available = true를 반환한다.
    - 유저가 일기를 생성한 적이 없는 경우가 포함된다.

## 관련 이슈

close #108 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
