### PR TITLE
 일기 생성시 빈 키워드를 받으면 키워드 자리에 Emotional을 작성하도록 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
@@ -1,13 +1,18 @@
 package tipitapi.drawmytoday.diary.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 @Service
+@Transactional(readOnly = true)
 public class PromptTextService {
 
     public String createPromptText(Emotion emotion, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            keyword = "emotional";
+        }
         return promptTextBuilder(
             emotion.getEmotionPrompt(),
             emotion.getColorPrompt(),

--- a/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
@@ -1,0 +1,58 @@
+package tipitapi.drawmytoday.diary.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
+import tipitapi.drawmytoday.emotion.domain.Emotion;
+
+@ExtendWith(MockitoExtension.class)
+class PromptTextServiceTest {
+
+    @InjectMocks
+    private PromptTextService promptTextService;
+
+    @Nested
+    @DisplayName("createPromptText 메서드는")
+    class CreatePromptTextTest {
+
+        @Nested
+        @DisplayName("keyword가")
+        class KeywordIs {
+
+            @Test
+            @DisplayName("null이면 keyword 자리에 emotional을 넣어 반환한다.")
+            void nullThanAddEmotional() throws Exception {
+                //given
+                Emotion emotion = TestEmotion.createEmotion();
+                String keyword = null;
+                //when
+                String promptText = promptTextService.createPromptText(emotion, keyword);
+
+                //then
+                assertThat(promptText).contains("emotional");
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = {"", " ", "  "})
+            @DisplayName("비어있으면 keyword 자리에 emotional을 넣어 반환한다.")
+            void emptyThanAddEmotional(String keyword) throws Exception {
+                //given
+                Emotion emotion = TestEmotion.createEmotion();
+
+                //when
+                String promptText = promptTextService.createPromptText(emotion, keyword);
+
+                //then
+                assertThat(promptText).contains("emotional");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 일기 생성 시 빈 키워드를 받으면 키워드 자리에 emotional을 작성하도록 수정

## 관련 이슈

close #117 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
