### PR TITLE
관리자용 일기 이미지/프롬프트 목록 조회 API 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/admin/controller/AdminController.java
@@ -35,7 +35,7 @@ public class AdminController {
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",
-            description = "일기 목록"),
+            description = "일기 목록. Pagination에 대한 세부 항목은 노션의 pageable 필드 설명 문서를 참고해주세요."),
         @ApiResponse(
             responseCode = "403",
             description = "D002 : 접근할 권한이 없습니다.",

--- a/src/main/java/tipitapi/drawmytoday/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/admin/controller/AdminController.java
@@ -1,0 +1,58 @@
+package tipitapi.drawmytoday.admin.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.admin.service.AdminService;
+import tipitapi.drawmytoday.common.resolver.AuthUser;
+import tipitapi.drawmytoday.common.response.SuccessResponse;
+import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Authentication")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Operation(summary = "일기 목록 조회", description = "일기의 프롬프트, 이미지 정보 목록을 반환하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "일기 목록"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 접근할 권한이 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @GetMapping("/diaries")
+    public ResponseEntity<SuccessResponse<Page<GetDiaryAdminResponse>>> getDiaries(
+        @Parameter(name = "size", description = "페이지네이션의 페이지당 데이터 수", in = ParameterIn.QUERY)
+        @RequestParam(value = "size", required = false, defaultValue = "20") int size,
+        @Parameter(name = "page", description = "페이지네이션의 페이지 넘버. 0부터 시작함", in = ParameterIn.QUERY)
+        @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+        @Parameter(name = "direction", description = "페이지네이션의 정렬기준. DESC=최신순, ASC=오래된순", in = ParameterIn.QUERY)
+        @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+    ) {
+        return SuccessResponse.of(
+            adminService.getDiaries(tokenInfo.getUserId(), size, page, direction)
+        ).asHttp(HttpStatus.OK);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/admin/dto/GetDiaryAdminResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/admin/dto/GetDiaryAdminResponse.java
@@ -1,0 +1,50 @@
+package tipitapi.drawmytoday.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Schema(description = "관리자용 일기 목록의 일기 정보 Response")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetDiaryAdminResponse {
+
+    @Schema(description = "일기 ID", requiredMode = RequiredMode.REQUIRED)
+    private final Long id;
+
+    @Schema(description = "일기 이미지 URL", requiredMode = RequiredMode.NOT_REQUIRED)
+    private final String imageURL;
+
+    @Schema(description = "일기 프롬프트", requiredMode = RequiredMode.NOT_REQUIRED)
+    private final String prompt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @Schema(description = "일기 작성 시간", requiredMode = RequiredMode.REQUIRED)
+    private final LocalDateTime createdAt;
+
+    public static GetDiaryAdminResponse of(Long id, String imageURL, String prompt,
+        LocalDateTime createdAt) {
+        return new GetDiaryAdminResponse(id, imageURL, prompt, createdAt);
+    }
+
+    public static class Page extends PageImpl<GetDiaryAdminResponse> {
+
+        public Page(List<GetDiaryAdminResponse> content,
+            Pageable pageable, long total) {
+            super(content, pageable, total);
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/admin/service/AdminService.java
@@ -1,0 +1,37 @@
+package tipitapi.drawmytoday.admin.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
+import tipitapi.drawmytoday.diary.service.AdminDiaryService;
+import tipitapi.drawmytoday.user.service.ValidateUserService;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final ValidateUserService validateUserService;
+    private final AdminDiaryService adminDiaryService;
+
+    public Page<GetDiaryAdminResponse> getDiaries(Long userId, int size, int page,
+        Direction direction) {
+        validateUserService.validateAdminUserById(userId);
+        return adminDiaryService.getDiaries(size, page, direction)
+            .map(this::buildGetDiaryAdminResponse);
+    }
+
+    private GetDiaryAdminResponse buildGetDiaryAdminResponse(
+        DiaryForMonitorQueryResponse response) {
+        LocalDateTime createdAt = LocalDateTime.parse(response.getCreatedAt(),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.n"));
+        return GetDiaryAdminResponse.of(response.getId(), response.getImageUrl(),
+            response.getPrompt(), createdAt);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -107,4 +107,15 @@ public class SwaggerConfiguration {
             .pathsToMatch(paths)
             .build();
     }
+
+    @Bean
+    public GroupedOpenApi adminOpenAPi() {
+        String[] paths = {"/admin/**"};
+
+        return GroupedOpenApi
+            .builder()
+            .group("관리자용 API")
+            .pathsToMatch(paths)
+            .build();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(409, "U002", "이미 존재하는 유저입니다."),
     DUPLICATE_USER(400, "U003", "유저가 중복되었습니다."),
     USER_ALREADY_DRAW_DIARY(400, "U004", "이미 그림일기를 그린 유저입니다."),
+    USER_ACCESS_DENIED(403, "U005", "접근할 수 있는 권한이 없습니다."),
 
     // Diary
     DIARY_NOT_FOUND(404, "D001", "일기를 찾을 수 없습니다."),

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/DiaryForMonitorQueryResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/DiaryForMonitorQueryResponse.java
@@ -1,0 +1,12 @@
+package tipitapi.drawmytoday.diary.dto;
+
+public interface DiaryForMonitorQueryResponse {
+
+    Long getId();
+
+    String getImageUrl();
+
+    String getPrompt();
+
+    String getCreatedAt();
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -3,9 +3,13 @@ package tipitapi.drawmytoday.diary.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
@@ -14,4 +18,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         LocalDateTime endMonth);
 
     Optional<Diary> findFirstByUserUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query(
+        value =
+            "SELECT d.diary_id AS id, i.image_url AS imageUrl, p.prompt_text AS prompt, d.created_at AS createdAt FROM diary AS d "
+                + "LEFT JOIN image AS i ON d.diary_id = i.diary_id "
+                + "LEFT JOIN prompt AS p ON d.diary_id = p.diary_id",
+        countQuery = "SELECT COUNT(*) FROM Diary",
+        nativeQuery = true
+    )
+    Page<DiaryForMonitorQueryResponse> getAllDiariesForMonitorAsPage(Pageable pageable);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/AdminDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/AdminDiaryService.java
@@ -1,0 +1,25 @@
+package tipitapi.drawmytoday.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
+import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminDiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    public Page<DiaryForMonitorQueryResponse> getDiaries(int size, int page,
+        Direction direction) {
+        return diaryRepository.getAllDiariesForMonitorAsPage(
+            PageRequest.of(page, size, Sort.by(direction, "created_at", "diary_id")));
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -76,4 +76,8 @@ public class User extends BaseEntityWithUpdate {
         return this.getLastDiaryDate() == null
             || !this.getLastDiaryDate().toLocalDate().equals(LocalDate.now());
     }
+
+    public boolean isAdmin() {
+        return this.userRole == UserRole.ADMIN;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/user/domain/UserRole.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/UserRole.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.user.domain;
 
 public enum UserRole {
-    GUEST("ROLE_GUEST"),
+    ADMIN("ROLE_ADMIN"),
     USER("ROLE_USER");
 
     private final String key;

--- a/src/main/java/tipitapi/drawmytoday/user/exception/UserAccessDeniedException.java
+++ b/src/main/java/tipitapi/drawmytoday/user/exception/UserAccessDeniedException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.user.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class UserAccessDeniedException extends BusinessException {
+
+    public UserAccessDeniedException() {
+        super(ErrorCode.USER_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -8,6 +8,7 @@ import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.exception.ErrorCode;
 import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.exception.UserAccessDeniedException;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.repository.UserRepository;
 
@@ -40,6 +41,15 @@ public class ValidateUserService {
                 return user;
             }
             throw new BusinessException(ErrorCode.USER_ALREADY_DRAW_DIARY);
+        }
+    }
+
+    public User validateAdminUserById(Long userId) {
+        User user = validateUserById(userId);
+        if (user.isAdmin()) {
+            return user;
+        } else {
+            throw new UserAccessDeniedException();
         }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/admin/controller/AdminControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/admin/controller/AdminControllerTest.java
@@ -1,0 +1,80 @@
+package tipitapi.drawmytoday.admin.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.web.servlet.ResultActions;
+import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.admin.service.AdminService;
+import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
+import tipitapi.drawmytoday.common.controller.WithCustomUser;
+
+@WebMvcTest(AdminController.class)
+@WithCustomUser
+class AdminControllerTest extends ControllerTestSetup {
+
+    private static final String BASIC_URL = "/admin";
+
+    @MockBean
+    private AdminService adminService;
+
+    @Nested
+    @DisplayName("getDiaries 메서드는")
+    class GetDiariesTest {
+
+        @Test
+        @DisplayName("모니터링을 위한 일기 데이터 목록을 Pagination 형태로 응답한다.")
+        void return_diaries_as_pagination() throws Exception {
+            // given
+            int size = 10;
+            int page = 0;
+            Direction direction = Direction.ASC;
+            Pageable pageable = PageRequest.of(page, size,
+                Sort.by(direction, "created_at", "diary_id"));
+            List<GetDiaryAdminResponse> diaries = new ArrayList<>();
+            diaries.add(GetDiaryAdminResponse.of(1L,
+                "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
+                "happy , pink , canvas-textured, Oil Pastel, a crowded subway",
+                LocalDateTime.now().minusDays(5)));
+            diaries.add(GetDiaryAdminResponse.of(2L,
+                "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
+                "angry , blue , glass-textured, crayon, school",
+                LocalDateTime.now().minusDays(1)));
+            given(adminService.getDiaries(anyLong(), anyInt(), anyInt(), any(Direction.class)))
+                .willReturn(new PageImpl<>(diaries, pageable, 2));
+
+            // when
+            ResultActions result = mockMvc.perform(get(BASIC_URL + "/diaries")
+                .queryParam("size", String.valueOf(size))
+                .queryParam("page", String.valueOf(page))
+                .queryParam("direction", "ASC"));
+
+            // then
+            result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].id").value(diaries.get(0).getId()))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.pageable").exists())
+                .andExpect(jsonPath("$.data.size").value(size))
+                .andExpect(jsonPath("$.data.number").value(page));
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
@@ -45,7 +45,7 @@ class AdminServiceTest {
 
         @Nested
         @DisplayName("관리자가 아닌 유저가 호출하면")
-        class IfUserIsNotAdmin {
+        class if_user_is_not_admin {
 
             @Test
             @DisplayName("UserAccessDeniedException 예외가 발생한다.")
@@ -63,7 +63,7 @@ class AdminServiceTest {
 
         @Nested
         @DisplayName("관리자인 유저가 호출하면")
-        class IfUserIsAdmin {
+        class is_user_is_admin {
 
             @Test
             @DisplayName("페이지네이션이 적용된 일기 목록을 반환한다.")

--- a/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
@@ -1,0 +1,105 @@
+package tipitapi.drawmytoday.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createAdminUserWithId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
+import tipitapi.drawmytoday.diary.service.AdminDiaryService;
+import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.exception.UserAccessDeniedException;
+import tipitapi.drawmytoday.user.service.ValidateUserService;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    ValidateUserService validateUserService;
+    @Mock
+    AdminDiaryService adminDiaryService;
+    @InjectMocks
+    AdminService adminService;
+
+    @Nested
+    @DisplayName("getDiaries 메소드 테스트")
+    class GetDiariesTest {
+
+        @Nested
+        @DisplayName("관리자가 아닌 유저가 호출하면")
+        class IfUserIsNotAdmin {
+
+            @Test
+            @DisplayName("UserAccessDeniedException 예외가 발생한다.")
+            void it_throws_UserAccessDeniedException() {
+                // given
+                given(validateUserService.validateAdminUserById(anyLong()))
+                    .willThrow(UserAccessDeniedException.class);
+
+                // when
+                // then
+                assertThatThrownBy(() -> adminService.getDiaries(1L, 10, 0, Direction.ASC))
+                    .isInstanceOf(UserAccessDeniedException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("관리자인 유저가 호출하면")
+        class IfUserIsAdmin {
+
+            @Test
+            @DisplayName("페이지네이션이 적용된 일기 목록을 반환한다.")
+            void it_returns_diaries_with_pagination() {
+                // given
+                User user = createAdminUserWithId(1L);
+                given(validateUserService.validateAdminUserById(anyLong())).willReturn(user);
+
+                List<DiaryForMonitorQueryResponse> diaries = new ArrayList<>();
+                diaries.add(createDiaryForMonitorQueryResponse(1L,
+                    "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
+                    "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
+                    "2023-06-16 15:00:00.0"));
+                diaries.add(createDiaryForMonitorQueryResponse(2L,
+                    "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
+                    "angry , purple , canvas-textured, Oil Pastel, school",
+                    "2023-06-17 15:00:00.0"));
+                given(adminDiaryService.getDiaries(any(Integer.class), any(Integer.class),
+                    any(Direction.class))).willReturn(new PageImpl<>(diaries));
+
+                // when
+                Page<GetDiaryAdminResponse> response = adminService.getDiaries(1L, 10, 0,
+                    Direction.ASC);
+
+                // then
+                assertThat(response.getContent().size()).isEqualTo(2);
+                assertThat(response.getContent().get(0).getId()).isEqualTo(1L);
+            }
+
+            private DiaryForMonitorQueryResponse createDiaryForMonitorQueryResponse(Long id,
+                String imageUrl, String prompt, String createdAt) {
+                ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+                Map<String, Object> map = Map.of("id", id, "imageUrl", imageUrl, "prompt", prompt,
+                    "createdAt", createdAt);
+                return factory.createProjection(DiaryForMonitorQueryResponse.class, map);
+            }
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestUser.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestUser.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.common.testdata;
 import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
+import tipitapi.drawmytoday.user.domain.UserRole;
 
 public class TestUser {
 
@@ -13,6 +14,12 @@ public class TestUser {
     public static User createUserWithId(Long userId) {
         User user = createUser();
         ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    public static User createAdminUserWithId(Long userId) {
+        User user = createUserWithId(userId);
+        ReflectionTestUtils.setField(user, "userRole", UserRole.ADMIN);
         return user;
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -15,9 +15,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.context.jdbc.Sql;
 import tipitapi.drawmytoday.common.BaseRepositoryTest;
 import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.user.domain.User;
 
@@ -210,6 +216,33 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
 
                 assertThat(diaryRepository.findById(1L)).isNotPresent();
 
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllDiariesForMonitorAsPage 메소드 테스트")
+    class GetAllDiariesForMonitorAsPageTest {
+
+        @Nested
+        @DisplayName("삭제된 일기가 있을 경우")
+        class if_deleted_diary_exist {
+
+            @Test
+            @DisplayName("삭제된 일기를 포함한 일기 리스트를 반환한다.")
+            @Sql("GetAllDiariesForMonitorAsPageTest.sql")
+            void return_diary_list_includes_deleted() {
+                int page = 0;
+                int size = 5;
+                Direction direction = Direction.DESC;
+                Page<DiaryForMonitorQueryResponse> response = diaryRepository.getAllDiariesForMonitorAsPage(
+                    PageRequest.of(page, size, Sort.by(direction, "created_at", "diary_id")));
+
+                assertThat(response.getTotalElements()).isEqualTo(10);
+                assertThat(response.getContent().size()).isEqualTo(5);
+                assertThat(response.getTotalPages()).isEqualTo(2);
+                assertThat(response.getSort().isSorted()).isTrue();
+                assertThat(response.getContent().get(0).getId()).isEqualTo(10L);
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
@@ -43,11 +43,11 @@ class AdminDiaryServiceTest {
             diaries.add(createDiaryForMonitorQueryResponse(1L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                 "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
-                "2023-06-16T15:00:00.000+00:00"));
+                "2023-06-16 15:00:00.0"));
             diaries.add(createDiaryForMonitorQueryResponse(2L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                 "angry , purple , canvas-textured, Oil Pastel, school",
-                "2023-06-17T15:00:00.000+00:00"));
+                "2023-06-17 15:00:00.0"));
             given(
                 diaryRepository.getAllDiariesForMonitorAsPage(any(Pageable.class)))
                 .willReturn(new PageImpl<>(diaries));

--- a/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
@@ -1,0 +1,76 @@
+package tipitapi.drawmytoday.diary.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
+import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDiaryServiceTest {
+
+    @Mock
+    DiaryRepository diaryRepository;
+    @InjectMocks
+    AdminDiaryService adminDiaryService;
+
+    @Nested
+    @DisplayName("getDiaries 메소드 테스트")
+    class GetDiariesTest {
+
+        @Test
+        @DisplayName("페이지네이션이 적용된 일기 목록을 반환한다.")
+        void it_returns_diaries_with_pagination() {
+            // given
+            List<DiaryForMonitorQueryResponse> diaries = new ArrayList<>();
+            diaries.add(createDiaryForMonitorQueryResponse(1L,
+                "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
+                "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
+                "2023-06-16T15:00:00.000+00:00"));
+            diaries.add(createDiaryForMonitorQueryResponse(2L,
+                "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
+                "angry , purple , canvas-textured, Oil Pastel, school",
+                "2023-06-17T15:00:00.000+00:00"));
+            given(
+                diaryRepository.getAllDiariesForMonitorAsPage(any(Pageable.class)))
+                .willReturn(new PageImpl<>(diaries));
+
+            // when
+            Page<DiaryForMonitorQueryResponse> response = adminDiaryService.getDiaries(10, 0,
+                Direction.ASC);
+
+            // then
+            assertThat(response.getContent().size()).isEqualTo(2);
+            assertThat(response.getContent().get(0).getId()).isEqualTo(1L);
+        }
+
+        private DiaryForMonitorQueryResponse createDiaryForMonitorQueryResponse(Long id,
+            String imageUrl, String prompt, String createdAt) {
+            ProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+            Map<String, Object> map = Map.of(
+                "id", id,
+                "imageUrl", imageUrl,
+                "prompt", prompt,
+                "createdAt", createdAt
+            );
+            return factory.createProjection(DiaryForMonitorQueryResponse.class, map);
+        }
+    }
+}

--- a/src/test/resources/tipitapi/drawmytoday/diary/repository/GetAllDiariesForMonitorAsPageTest.sql
+++ b/src/test/resources/tipitapi/drawmytoday/diary/repository/GetAllDiariesForMonitorAsPageTest.sql
@@ -1,0 +1,113 @@
+INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_diary_date,
+                    social_code, user_role)
+VALUES (1, '2023-03-01T15:20:02.236278', '2023-03-01T15:20:02.236278', null, null,
+        '2023-03-14T15:20:02.236278', 'GOOGLE', 'ADMIN');
+INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_diary_date,
+                    social_code, user_role)
+VALUES (2, '2023-03-02T15:20:02.236278', '2023-03-21T15:20:02.236278', null, null,
+        '2023-03-16T15:20:02.236278', 'APPLE', 'USER');
+INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_diary_date,
+                    social_code, user_role)
+VALUES (3, '2023-04-01T15:20:02.236278', '2023-04-04T15:20:02.236278', null, null,
+        '2023-03-18T15:20:02.236278', 'APPLE', 'ADMIN');
+INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_diary_date,
+                    social_code, user_role)
+VALUES (4, '2023-05-01T15:20:02.236278', '2023-05-02T15:20:02.236278', null, null,
+        '2023-03-20T15:20:02.236278', 'GOOGLE', 'USER');
+
+INSERT INTO `emotion` (emotion_id, created_at, color, color_prompt, emotion_prompt, is_active, name)
+VALUES (1, '2023-02-01T15:20:02.236278', '#FF0000', 'Blue', 'sadness', 1, '슬픔');
+INSERT INTO `emotion` (emotion_id, created_at, color, color_prompt, emotion_prompt, is_active, name)
+VALUES (2, '2023-02-02T15:20:02.236278', '#FF0203', 'Pink', 'happiness', 1, '행복');
+INSERT INTO `emotion` (emotion_id, created_at, color, color_prompt, emotion_prompt, is_active, name)
+VALUES (3, '2023-02-03T15:20:02.236278', '#FF9203', 'Orange', 'joyful', 1, '즐거움');
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (1, '2023-03-13T15:20:02.236278', '2023-03-15T15:20:02.236278', '2023-05-02T07:13:04.971623',
+        '2023-03-03T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 1, 1);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (1, '2023-03-13T15:20:02.236278', '/diary/1.png', 1, 1);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (1, '2023-03-13T15:20:02.236278', 1, 'this is prompt of diary 1', 1);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (2, '2023-03-14T15:20:02.236278', '2023-03-15T15:20:02.236278', null,
+        '2023-03-14T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 1, 1);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (2, '2023-03-14T15:20:02.236278', '/diary/2.png', 1, 2);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (2, '2023-03-14T15:20:02.236278', 1, 'this is prompt of diary 2', 2);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (3, '2023-03-15T15:20:02.236278', '2023-03-15T15:20:02.236278', null,
+        '2023-03-15T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 1, 2);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (3, '2023-03-13T15:20:02.236278', '/diary/3.png', 1, 3);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (3, '2023-03-13T15:20:02.236278', 1, 'this is prompt of diary 3', 3);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (4, '2023-03-16T15:20:02.236278', '2023-03-16T15:20:02.236278', '2023-04-02T07:13:04.971623',
+        '2023-03-12T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 1, 2);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (4, '2023-03-16T15:20:02.236278', '/diary/4.png', 1, 4);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (4, '2023-03-16T15:20:02.236278', 1, 'this is prompt of diary 4', 4);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (5, '2023-03-17T15:20:02.236278', '2023-03-17T15:20:02.236278', null,
+        '2023-03-17T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 1, 3);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (5, '2023-03-17T15:20:02.236278', '/diary/5.png', 1, 5);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (5, '2023-03-17T15:20:02.236278', 1, 'this is prompt of diary 5', 5);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (6, '2023-03-18T15:20:02.236278', '2023-03-18T15:20:02.236278', null,
+        '2023-03-18T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 2, 3);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (6, '2023-03-18T15:20:02.236278', '/diary/6.png', 1, 6);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (6, '2023-03-18T15:20:02.236278', 1, 'this is prompt of diary 6', 6);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (7, '2023-03-19T15:20:02.236278', '2023-03-19T15:20:02.236278', null,
+        '2023-03-19T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 2, 4);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (7, '2023-03-19T15:20:02.236278', '/diary/7.png', 1, 7);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (7, '2023-03-19T15:20:02.236278', 1, 'this is prompt of diary 7', 7);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (8, '2023-03-20T15:20:02.236278', '2023-03-20T15:20:02.236278', null,
+        '2023-03-20T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 2, 4);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (8, '2023-03-20T15:20:02.236278', '/diary/8.png', 1, 8);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (8, '2023-03-20T15:20:02.236278', 1, 'this is prompt of diary 8', 8);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (9, '2023-03-21T15:20:02.236278', '2023-03-21T15:20:02.236278', '2023-06-02T07:13:04.971623',
+        '2023-03-21T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 3, 1);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (9, '2023-03-13T15:20:02.236278', '/diary/9.png', 1, 9);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (9, '2023-03-13T15:20:02.236278', 1, 'this is prompt of diary 9', 9);
+
+INSERT INTO `diary` (diary_id, created_at, updated_at, deleted_at, diary_date, is_ai, notes, review,
+                     title, weather, emotion_id, user_id)
+VALUES (10, '2023-03-22T15:20:02.236278', '2023-03-22T15:20:02.236278', null,
+        '2023-03-22T15:20:02.236278', 0, 'this is note', 'GOOD', 'title', 'sunny', 3, 2);
+INSERT INTO `image` (image_id, created_at, image_url, is_selected, diary_id)
+VALUES (10, '2023-03-13T15:20:02.236278', '/diary/10.png', 1, 10);
+INSERT INTO `prompt` (prompt_id, created_at, is_success, prompt_text, diary_id)
+VALUES (10, '2023-03-13T15:20:02.236278', 1, 'this is prompt of diary 10', 10);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

관리자 권한 Enum 추가
- UserRole.ADMIN 추가
- UserRole.GUEST 삭제

User의 관리자 검증 메소드 추가
- ValidateUserService.validateAdminUserById() 메소드 추가
- 해당 유저가 관리자 권한인지 반환하는 User.isAdmin() 메소드 추가

관리자용 일기 목록 조회 API 추가
- [GET] /admin/diaries
- admin 패키지의 AdminController, AdminService 클래스 추가
- diary 패키지의 AdminDiaryService 추가
- diary 패키지의 DiaryRepository에 getAllDiariesForMonitorAsPage 메소드 추가
- 일기 자체를 반환하는 작업은 diary 패키지에서 처리하는것이 도메인 분류상 맞기 때문에, AdminController가 AdminService를 호출하면, AdminService가 AdminDiaryService를 통해 일기 데이터를 받아옵니다.
- AdminService는 받아온 일기 데이터를 응답 dto에 맞게 처리하여 AdminController로 반환합니다.

관리자 테스트 유저 객체 생성 메소드 추가
- TestUser 클래스에 createAdminUserWithId 메소드 추가

## 관련 이슈

close #116 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
