### PR TITLE
관리자용 일기 목록 조회시 이미지 S3 URL로 발급

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/admin/service/AdminService.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.admin.service;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.diary.dto.DiaryForMonitorQueryResponse;
 import tipitapi.drawmytoday.diary.service.AdminDiaryService;
+import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
 
 @Service
@@ -19,6 +21,9 @@ public class AdminService {
 
     private final ValidateUserService validateUserService;
     private final AdminDiaryService adminDiaryService;
+    private final S3PreSignedService s3PreSignedService;
+    @Value("${presigned-image.expiration.admin-diaries}")
+    private int getDiariesExpiration;
 
     public Page<GetDiaryAdminResponse> getDiaries(Long userId, int size, int page,
         Direction direction) {
@@ -31,7 +36,9 @@ public class AdminService {
         DiaryForMonitorQueryResponse response) {
         LocalDateTime createdAt = LocalDateTime.parse(response.getCreatedAt(),
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.n"));
-        return GetDiaryAdminResponse.of(response.getId(), response.getImageUrl(),
-            response.getPrompt(), createdAt);
+        String imageUrl = s3PreSignedService.getPreSignedUrlForShare(response.getImageUrl(),
+            getDiariesExpiration);
+        return GetDiaryAdminResponse.of(response.getId(), imageUrl, response.getPrompt(),
+            createdAt);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
 encryptor:
     secret:
         key: ${ENCRYPTOR_SECRET_KEY}
+presigned-image:
+    expiration:
+        admin-diaries: ${PRESIGNED_IMAGE_EXPIRATION_ADMIN_DIARIES}
+


### PR DESCRIPTION
# 구현 내용

## 구현 요약

관리자용 일기 목록 조회시 이미지 S3 URL로 발급
- 기존에는 이미지 URI로 발급했으나, S3 Presigned URL로 발급하도록 수정
- 환경변수 PRESIGNED_IMAGE_EXPIRATION_ADMIN_DIARIES 을 등록하여, 이미지 유효시간을 유연하게 변경할 수 있도록 함
- 환경변수 노션/Github Actions Secret 등록 완료!

## 관련 이슈

close #116 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
