### PR TITLE
자잘한 버그와 네이밍 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -194,7 +194,7 @@ public class DiaryController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "일기 생성 가능 여부 조회", description = "유저가 금일 일기를 생성할 수 있는지 여부를 반환한다.")
+    @Operation(summary = "일기 생성 가능 여부 조회", description = "유저가 일기를 생성할 수 있는지 여부를 반환한다.")
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -24,7 +24,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "SELECT d.diary_id AS id, i.image_url AS imageUrl, p.prompt_text AS prompt, d.created_at AS createdAt FROM diary AS d "
                 + "LEFT JOIN image AS i ON d.diary_id = i.diary_id "
                 + "LEFT JOIN prompt AS p ON d.diary_id = p.diary_id",
-        countQuery = "SELECT COUNT(*) FROM Diary",
+        countQuery = "SELECT COUNT(*) FROM diary",
         nativeQuery = true
     )
     Page<DiaryForMonitorQueryResponse> getAllDiariesForMonitorAsPage(Pageable pageable);

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -77,8 +77,8 @@ public class CreateDiaryService {
         }
     }
 
-    private void validateCreateDiaryDate(LocalDate createDiaryDate) {
-        if (createDiaryDate.isAfter(LocalDate.now())) {
+    private void validateCreateDiaryDate(LocalDate diaryDate) {
+        if (diaryDate.isAfter(LocalDate.now())) {
             throw new BusinessException(ErrorCode.INVALID_CREATE_DIARY_DATE);
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- DiaryRepository의 getAllDiariesForMonitorAsPage 메서드 네이티브쿼리 오타 수정(Diary -> diary)
<img width="751" alt="image" src="https://github.com/tipi-tapi/ai-paint-today-BE/assets/39454230/88b3da76-fcb0-4a45-8b01-e52709724944"><br>
위와 같이 Diary라고 작성하면 테이블을 못 찾아서 수정했습니다!
- 자잘한 네이밍 수정
- 일기 생성 가능 여부 조회 API의 스웨거 설명 수정

## 관련 이슈

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
