### PR TITLE
Apple client secret 생성 로직 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,9 @@ jobs:
                     oauth2.google.redirect-uri: ${{ secrets.GOOGLE_REDIRECT_URI }}
                     oauth2.google.delete-account-url: ${{ secrets.GOOGLE_DELETE_ACCOUNT_URL }}
                     oauth2.apple.ios.client-id: ${{ secrets.APPLE_IOS_CLIENT_ID }}
-                    oauth2.apple.ios.client-secret: ${{ secrets.APPLE_IOS_CLIENT_SECRET }}
+                    oauth2.apple.ios.team-id: ${{ secrets.APPLE_IOS_TEAM_ID }}
+                    oauth2.apple.ios.key-id: ${{ secrets.APPLE_IOS_KEY_ID }}
+                    oauth2.apple.ios.private-id: ${{ secrets.APPLE_IOS_PRIVATE_KEY }}
                     oauth2.apple.ios.token-url: ${{ secrets.APPLE_IOS_TOKEN_URL }}
                     oauth2.apple.ios.delete-account-url: ${{ secrets.APPLE_IOS_DELETE_ACCOUNT_URL }}
                     jwt.secret: ${{ secrets.JWT_SECRET }}

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
 //	스프링 시큐리티, jwt 설정
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-jwt:1.1.1.RELEASE'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
     // OAuth
     OAUTH_NOT_FOUND(404, "O001", "유저의 refresh token을 찾을 수 없습니다."),
     OAUTH_SERVER_FAILED(500, "O002", "OAuth 서버와의 통신 중 에러가 발생하였습니다."),
+    GENERATE_KEY_FAILED(500, "O003", "키 생성에 실패하였습니다."),
 
     // REST
     REST_CLIENT_FAILED(500, "R001", "외부로의 REST 통신에 실패하였습니다.");

--- a/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleClientSecret.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleClientSecret.java
@@ -1,0 +1,87 @@
+package tipitapi.drawmytoday.oauth.properties;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.stereotype.Component;
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class AppleClientSecret {
+
+    private final ObjectMapper objectMapper;
+    private String clientSecret;
+
+    private String generateClientSecret(String teamId, String keyId, String privateKey,
+        String clientId, int expireDays) {
+        Date expirationDate = Date.from(
+            LocalDateTime.now().plusDays(expireDays).atZone(ZoneId.systemDefault()).toInstant());
+        Map<String, Object> jwtHeader = new HashMap<>();
+        jwtHeader.put("kid", keyId);
+        jwtHeader.put("alg", "ES256");
+
+        return Jwts.builder()
+            .setHeaderParams(jwtHeader)
+            .setIssuer(teamId)
+            .setIssuedAt(new Date(System.currentTimeMillis()))
+            .setExpiration(expirationDate)
+            .setAudience("https://appleid.apple.com")
+            .setSubject(clientId)
+            .signWith(getPrivateKey(privateKey), SignatureAlgorithm.ES256)
+            .compact();
+    }
+
+    private PrivateKey getPrivateKey(String privateKey) {
+        try (StringReader stringReader = new StringReader(privateKey);
+            PEMParser pemParser = new PEMParser(stringReader)) {
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(pemParser.readObject());
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.GENERATE_KEY_FAILED, e);
+        }
+    }
+
+    private boolean isClientSecretNotValidOrExpired() {
+        if (clientSecret == null) {
+            return true;
+        }
+        String[] jsonToken = clientSecret.split("\\.");
+        if (jsonToken.length != 3) {
+            return true;
+        }
+        byte[] payloadBytes = Base64.getUrlDecoder().decode(jsonToken[1]);
+        try {
+            JsonNode payloadNode = objectMapper.readTree(payloadBytes);
+            long expirationTime = payloadNode.get("exp").asLong() * 1000;
+            long currentTime = System.currentTimeMillis();
+            return expirationTime < currentTime;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+
+    public String getClientSecret(String teamId, String keyId, String privateKey,
+        String clientId) {
+        if (isClientSecretNotValidOrExpired()) {
+            clientSecret = generateClientSecret(teamId, keyId, privateKey, clientId, 29);
+        }
+        return clientSecret;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleClientSecret.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleClientSecret.java
@@ -28,6 +28,14 @@ public class AppleClientSecret {
     private final ObjectMapper objectMapper;
     private String clientSecret;
 
+    public String getClientSecret(String teamId, String keyId, String privateKey,
+        String clientId) {
+        if (isClientSecretNotValidOrExpired()) {
+            clientSecret = generateClientSecret(teamId, keyId, privateKey, clientId, 29);
+        }
+        return clientSecret;
+    }
+
     private String generateClientSecret(String teamId, String keyId, String privateKey,
         String clientId, int expireDays) {
         Date expirationDate = Date.from(
@@ -77,11 +85,4 @@ public class AppleClientSecret {
         }
     }
 
-    public String getClientSecret(String teamId, String keyId, String privateKey,
-        String clientId) {
-        if (isClientSecretNotValidOrExpired()) {
-            clientSecret = generateClientSecret(teamId, keyId, privateKey, clientId, 29);
-        }
-        return clientSecret;
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/properties/ApplePrivateKey.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/properties/ApplePrivateKey.java
@@ -1,0 +1,17 @@
+package tipitapi.drawmytoday.oauth.properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplePrivateKey {
+
+    @Value("${oauth2.apple.ios.private-key}")
+    private String privateKey;
+
+    public String getPrivateKey() {
+        return "-----BEGIN PRIVATE KEY-----\n"
+            + privateKey
+            + "\n-----END PRIVATE KEY-----";
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleProperties.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleProperties.java
@@ -1,16 +1,19 @@
 package tipitapi.drawmytoday.oauth.properties;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 @Component
 @Getter
-@NoArgsConstructor
+@RequiredArgsConstructor
 @PropertySource("classpath:application-oauth.yml")
 public class AppleProperties {
+
+    private final AppleClientSecret clientSecret;
+    private final ApplePrivateKey privateKey;
 
     @Value("${oauth2.apple.ios.client-id}")
     private String clientId;
@@ -18,14 +21,12 @@ public class AppleProperties {
     private String teamId;
     @Value("${oauth2.apple.ios.key-id}")
     private String keyId;
-    @Value("${oauth2.apple.ios.private-key}")
-    private String privateKey;
     @Value("${oauth2.apple.ios.token-url}")
     private String tokenUrl;
     @Value("${oauth2.apple.ios.delete-account-url}")
     private String deleteAccountUrl;
 
     public String getClientSecret() {
-        return null;
+        return clientSecret.getClientSecret(teamId, keyId, privateKey.getPrivateKey(), clientId);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleProperties.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/properties/AppleProperties.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.oauth.properties;
 
-import java.util.Date;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,14 +13,19 @@ import org.springframework.stereotype.Component;
 public class AppleProperties {
 
     @Value("${oauth2.apple.ios.client-id}")
-    private String iosClientId;
-    @Value("${oauth2.apple.ios.client-secret}")
-    private String iosClientSecret;
+    private String clientId;
+    @Value("${oauth2.apple.ios.team-id}")
+    private String teamId;
+    @Value("${oauth2.apple.ios.key-id}")
+    private String keyId;
+    @Value("${oauth2.apple.ios.private-key}")
+    private String privateKey;
     @Value("${oauth2.apple.ios.token-url}")
     private String tokenUrl;
     @Value("${oauth2.apple.ios.delete-account-url}")
-    private String iosDeleteAccountUrl;
+    private String deleteAccountUrl;
 
-    private Date iosClientSecretExpireDate;
-
+    public String getClientSecret() {
+        return null;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -85,14 +85,14 @@ public class AppleOAuthService {
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("client_id", properties.getIosClientId());
-        body.add("client_secret", properties.getIosClientSecret());
+        body.add("client_id", properties.getClientId());
+        body.add("client_secret", properties.getClientSecret());
         body.add("token", refreshToken);
         body.add("token_type_hint", "refresh_token");
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
-        String url = properties.getIosDeleteAccountUrl();
+        String url = properties.getDeleteAccountUrl();
 
         String response = restTemplate.postForObject(url, request, String.class);
         if (response != null) {
@@ -107,8 +107,8 @@ public class AppleOAuthService {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        String clientId = properties.getIosClientId();
-        String clientSecret = properties.getIosClientSecret();
+        String clientId = properties.getClientId();
+        String clientSecret = properties.getClientSecret();
         String appleTokenUrl = properties.getTokenUrl();
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -9,7 +9,9 @@ oauth2:
     apple:
         ios:
             client-id: ${APPLE_IOS_CLIENT_ID}
-            client-secret: ${APPLE_IOS_CLIENT_SECRET}
+            team-id: ${APPLE_IOS_TEAM_ID}
+            key-id: ${APPLE_IOS_KEY_ID}
+            private-key: ${APPLE_IOS_PRIVATE_KEY}
             token-url: ${APPLE_IOS_TOKEN_URL}
             delete-account-url: ${APPLE_IOS_DELETE_ACCOUNT_URL}
 

--- a/src/test/java/tipitapi/drawmytoday/oauth/integrate/ApplePropertiesTest.java
+++ b/src/test/java/tipitapi/drawmytoday/oauth/integrate/ApplePropertiesTest.java
@@ -1,0 +1,75 @@
+package tipitapi.drawmytoday.oauth.integrate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import tipitapi.drawmytoday.oauth.properties.AppleClientSecret;
+import tipitapi.drawmytoday.oauth.properties.AppleProperties;
+
+@SpringBootTest
+public class ApplePropertiesTest {
+
+    @Autowired
+    AppleProperties appleProperties;
+    @Autowired
+    AppleClientSecret appleClientSecret;
+
+    @Nested
+    @DisplayName("getClientSecret 메서드는")
+    class GetClientSecretMethod {
+
+        @AfterEach
+        void initializeAppleProperties() {
+            ReflectionTestUtils.setField(appleClientSecret, "clientSecret", null);
+        }
+
+        @Test
+        @DisplayName("처음 호출하면 null이 아닌 값을 반환한다")
+        void when_call_first_then_not_return_null() {
+            // given
+            // when
+            String clientSecret = appleProperties.getClientSecret();
+
+            // then
+            assertThat(clientSecret).isNotNull();
+        }
+
+        @Test
+        @DisplayName("두 번째 호출시 기존 토큰이 만료되지 않았다면 기존 토큰을 반환한다")
+        void call_twice_not_expired() {
+            // given
+            // when
+            String firstToken = appleProperties.getClientSecret();
+            String secondToken = appleProperties.getClientSecret();
+
+            // then
+            assertThat(firstToken).isEqualTo(secondToken);
+        }
+
+        @Test
+        @DisplayName("두 번째 호출시 기존 토큰이 만료되었다면 새로운 토큰을 반환한다")
+        void call_twice_expired() {
+            // given
+            // when
+            String firstToken = appleProperties.getClientSecret();
+            String expiredClientSecret = ReflectionTestUtils.invokeMethod(appleClientSecret,
+                "generateClientSecret",
+                appleProperties.getTeamId(), appleProperties.getKeyId(),
+                appleProperties.getPrivateKey().getPrivateKey(),
+                appleProperties.getClientId(), 0);
+            ReflectionTestUtils.setField(appleClientSecret, "clientSecret",
+                expiredClientSecret);
+            String secondToken = appleProperties.getClientSecret();
+
+            // then
+            assertThat(firstToken).isNotEqualTo(secondToken);
+        }
+    }
+
+}


### PR DESCRIPTION
# 구현 내용

기존 애플리케이션은 apple client secret을 환경변수에 저장하여 사용했습니다. 다만, apple client secret은 만료기간이 30일 이내의 jwt 토큰으로 만들어야 유효합니다. 따라서 29일이 지나면 수동으로 환경변수를 바꾸고, 애플리케이션을 다시 시작해야되는 불편함이 있습니다.

따라서 client secret을 환경변수가 아닌 애플리케이션 내부에서 생성하고, 관리하는 방식으로 변경하여 매 요청시 토큰 만료 여부를 확인하도록 구현했습니다. 만약 토큰이 만료되지 않았다면 기존 토큰을 활용하고, 만료됐다면 토큰을 새로 만들어 저장하고, 반환하는 형식입니다. 

구현 이후 [validate refresh token](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens#3605122) api를 호출하여 검증도 완료했습니다.

## 구현 요약
- BouncyCastle 라이브러리 의존성 추가
- 환경변수 APPLE_IOS_CLIENT_SECRET 삭제, APPLE_IOS_KEY_ID, APPLE_IOS_PRIVATE_KEY, APPLE_IOS_TEAM_ID 추가
- AppleClientSecret 클래스 구현
- AppleProperties 통합테스트 작성

---

__해당 PR이 머지되면 테스트 서버에 환경변수 등록 후 실제 애플 소셜로그인이 정상적으로 되는지 검증하겠습니다!__

## 관련 이슈

close #13 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
