### PR TITLE
로그 레벨에 따른 파일 분리 및 로그 설정 추가 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+logs/
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-logging'
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation platform('software.amazon.awssdk:bom:2.20.26')
@@ -64,9 +65,9 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
-                exclude: [
-                    'tipitapi/drawmytoday/common/**'
-                ])
+                    exclude: [
+                            'tipitapi/drawmytoday/common/**'
+                    ])
         }))
     }
 
@@ -86,7 +87,7 @@ jacocoTestCoverageVerification {
             }
 
             excludes = [
-                'tipitapi/drawmytoday/common/**'
+                    'tipitapi/drawmytoday/common/**'
             ]
         }
     }

--- a/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.common.log.MDCRequestLoggingFilter;
 import tipitapi.drawmytoday.common.security.jwt.JwtAuthenticationEntryPoint;
 import tipitapi.drawmytoday.common.security.jwt.JwtAuthenticationFilter;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
@@ -58,7 +59,8 @@ public class SecurityConfig {
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, permitAllEndpointList),
                 UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(new JwtAuthenticationEntryPoint(objectMapper()),
-                JwtAuthenticationFilter.class);
+                JwtAuthenticationFilter.class)
+            .addFilterBefore(new MDCRequestLoggingFilter(), JwtAuthenticationEntryPoint.class);
 
         return http.build();
     }

--- a/src/main/java/tipitapi/drawmytoday/common/log/MDCRequestLoggingFilter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/log/MDCRequestLoggingFilter.java
@@ -1,0 +1,21 @@
+package tipitapi.drawmytoday.common.log;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class MDCRequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        MDC.put("request_id", UUID.randomUUID().toString());
+        filterChain.doFilter(request, response);
+        MDC.clear();
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,6 +8,54 @@
 
   <property name="LOG_PATH" value="./logs"/>
 
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
   <springProfile name="develop">
 
     <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
@@ -23,55 +71,6 @@
 
   <springProfile name="test">
     <property name="LOG_PATH" value="~/TipiTapiTestServer/log"/>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>INFO</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>WARN</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>ERROR</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
     <root level="INFO">
       <appender-ref ref="FILE_INFO"/>
       <appender-ref ref="FILE_WARN"/>
@@ -81,55 +80,6 @@
 
   <springProfile name="prod">
     <property name="LOG_PATH" value="~/SpringServer/log"/>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>INFO</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>WARN</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
-      <encoder>
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-      </encoder>
-      <filter class="ch.qos.logback.classic.filter.LevelFilter">
-        <level>ERROR</level>
-        <onMatch>ACCEPT</onMatch>
-        <onMismatch>DENY</onMismatch>
-      </filter>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
-        <maxHistory>12</maxHistory>
-        <totalSizeCap>100MB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
-
     <root level="INFO">
       <appender-ref ref="FILE_INFO"/>
       <appender-ref ref="FILE_WARN"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,89 @@
+<configuration>
+
+  <property name="CONSOLE_LOG_PATTERN"
+    value="[%d{HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+  <property name="FILE_LOG_PATTERN"
+    value="[%d{HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+  <property name="LOG_PATH" value="./logs"/>
+
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>INFO</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>WARN</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
+    <encoder>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.LevelFilter">
+      <level>ERROR</level>
+      <onMatch>ACCEPT</onMatch>
+      <onMismatch>DENY</onMismatch>
+    </filter>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
+      <maxHistory>12</maxHistory>
+      <totalSizeCap>100MB</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <springProfile name="develop">
+
+    <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
+      <encoder>
+        <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+      </encoder>
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="STDOUT"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="test">
+    <property name="LOG_PATH" value="~/TipiTapiTestServer/log"/>
+    <root level="INFO">
+      <appender-ref ref="FILE_INFO"/>
+      <appender-ref ref="FILE_WARN"/>
+      <appender-ref ref="FILE_ERROR"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="prod">
+    <property name="LOG_PATH" value="./logs"/>
+    <root level="INFO">
+      <appender-ref ref="FILE_INFO"/>
+      <appender-ref ref="FILE_WARN"/>
+      <appender-ref ref="FILE_ERROR"/>
+    </root>
+  </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,60 +1,12 @@
 <configuration>
 
   <property name="CONSOLE_LOG_PATTERN"
-    value="[%d{HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    value="[%d{HH:mm:ss.SSS}] [%blue(%X{request_id})] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
 
   <property name="FILE_LOG_PATTERN"
-    value="[%d{HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    value="[%d{HH:mm:ss.SSS}] [%blue(%X{request_id})] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
 
   <property name="LOG_PATH" value="./logs"/>
-
-  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>INFO</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
-      <maxHistory>12</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-  </appender>
-
-  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>WARN</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
-      <maxHistory>12</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-  </appender>
-
-  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
-    <encoder>
-      <pattern>${FILE_LOG_PATTERN}</pattern>
-    </encoder>
-    <filter class="ch.qos.logback.classic.filter.LevelFilter">
-      <level>ERROR</level>
-      <onMatch>ACCEPT</onMatch>
-      <onMismatch>DENY</onMismatch>
-    </filter>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
-      <maxHistory>12</maxHistory>
-      <totalSizeCap>100MB</totalSizeCap>
-    </rollingPolicy>
-  </appender>
 
   <springProfile name="develop">
 
@@ -71,6 +23,55 @@
 
   <springProfile name="test">
     <property name="LOG_PATH" value="~/TipiTapiTestServer/log"/>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>INFO</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>WARN</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
     <root level="INFO">
       <appender-ref ref="FILE_INFO"/>
       <appender-ref ref="FILE_WARN"/>
@@ -79,7 +80,56 @@
   </springProfile>
 
   <springProfile name="prod">
-    <property name="LOG_PATH" value="./logs"/>
+    <property name="LOG_PATH" value="~/SpringServer/log"/>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_INFO">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>INFO</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/info-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_WARN">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>WARN</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/warn-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
+    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="FILE_ERROR">
+      <encoder>
+        <pattern>${FILE_LOG_PATTERN}</pattern>
+      </encoder>
+      <filter class="ch.qos.logback.classic.filter.LevelFilter">
+        <level>ERROR</level>
+        <onMatch>ACCEPT</onMatch>
+        <onMismatch>DENY</onMismatch>
+      </filter>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/error-%d{yyyy-MM}.log</fileNamePattern>
+        <maxHistory>12</maxHistory>
+        <totalSizeCap>100MB</totalSizeCap>
+      </rollingPolicy>
+    </appender>
+
     <root level="INFO">
       <appender-ref ref="FILE_INFO"/>
       <appender-ref ref="FILE_WARN"/>


### PR DESCRIPTION
# 구현 내용

로그 설정에 대해 정리가 필요할 것 같아 [노션 페이지](https://knowing-jester-927.notion.site/b8d2cedff35c46df9c3e08570982194c?pvs=4)에 Logback과 MDC를 정리했습니다!

## 구현 요약

- spring-boot-starter-logging 의존성 추가
- 각 월에 따라 로그 파일 분리
- 로그 파일 크기 100mb로 제한
- log에 request_id 추가(UUID)

## 관련 이슈

close #138 

## 전달사항
logback-spring.xml 파일을 작성하는 도중 코드를 저장하면 google code style에 따라 appender가 property보다 먼저 위치하도록 변경되어 appender가 property를 읽지 못하는 오류가 발생했습니다. 

따라서 xml 파일은 google code style의 위치 구성이 적용되지 않도록 
Editor -> Code Style -> XML 설정에서 Arrangement의 모든 코드 순서를 지웠습니다.(원래 property 순서만 조정하려 했는데 생각보다 property의 순서만 제외하기 쉽지 않아서 전부 지우는 다소 극단적인? 선택을 했습니다)

따라서 xml 파일에 대한 코드 순서가 통일되지 않지만.. 뷰 템플릿이나 MyBatis를 사용하지도 않기에 앞으로 xml 파일을 만들 경우가 없지 않을까 하는 생각이 듭니다. 하지만 다른 분들의 개발환경도 같은 환경을 구성해야 하기에 `Preference -> Editor -> Code Style -> XML 설정에서 Arrangement의 모든 순서` 를 지우셔야 할 것 같습니다.

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
