### PR TITLE
일기 생성 시 키워드가 없으면 eomtional이 아닌 emotions로 대체되도록 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
@@ -11,7 +11,7 @@ public class PromptTextService {
 
     public String createPromptText(Emotion emotion, String keyword) {
         if (!StringUtils.hasText(keyword)) {
-            keyword = "emotional";
+            keyword = "emotions";
         }
         return promptTextBuilder(
             emotion.getEmotionPrompt(),


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 일기 생성 시 키워드가 없으면 eomtional이 아닌 emotions로 대체되도록 변경

## 관련 이슈

close #140 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
