### PR TITLE
일기 생성 API와 관련된 diaryDate 필드 검증 방식 변경, 코드 아키텍처 리팩토링

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/validator/DiaryDateValidator.java
+++ b/src/main/java/tipitapi/drawmytoday/common/validator/DiaryDateValidator.java
@@ -1,0 +1,17 @@
+package tipitapi.drawmytoday.common.validator;
+
+import java.time.LocalDate;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class DiaryDateValidator implements ConstraintValidator<ValidDiaryDate, LocalDate> {
+
+    @Override
+    public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return !value.isAfter(LocalDate.now());
+    }
+
+}

--- a/src/main/java/tipitapi/drawmytoday/common/validator/ValidDiaryDate.java
+++ b/src/main/java/tipitapi/drawmytoday/common/validator/ValidDiaryDate.java
@@ -1,0 +1,21 @@
+package tipitapi.drawmytoday.common.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DiaryDateValidator.class)
+@Documented
+public @interface ValidDiaryDate {
+
+    String message() default "미래의 날짜는 입력할 수 없습니다.";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -163,11 +163,19 @@ public class DiaryController {
         @Parameter(description = "테스트 여부", in = ParameterIn.QUERY)
         @RequestParam(value = "test", required = false, defaultValue = "false") boolean test
     ) throws DallERequestFailException, ImageInputStreamFailException {
-        return SuccessResponse.of(
-            createDiaryService.createDiary(tokenInfo.getUserId(), createDiaryRequest.getEmotionId(),
+        CreateDiaryResponse response;
+        if (test) {
+            response = createDiaryService.createTestDiary(tokenInfo.getUserId(),
+                createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate(), test)
-        ).asHttp(HttpStatus.CREATED);
+                createDiaryRequest.getDiaryDate());
+        } else {
+            response = createDiaryService.createDiary(tokenInfo.getUserId(),
+                createDiaryRequest.getEmotionId(),
+                createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
+                createDiaryRequest.getDiaryDate());
+        }
+        return SuccessResponse.of(response).asHttp(HttpStatus.CREATED);
     }
 
     @Operation(summary = "일기 수정", description = "주어진 일기의 내용을 수정한다.")

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -24,8 +24,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
-import tipitapi.drawmytoday.common.exception.BusinessException;
-import tipitapi.drawmytoday.common.exception.ErrorCode;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.user.domain.User;
 
@@ -99,7 +97,7 @@ public class Diary extends BaseEntityWithUpdate {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(validateCreateDiaryDate(diaryDate))
+            .diaryDate(diaryDate.atTime(LocalTime.now()))
             .notes(notes)
             .isAi(true)
             .isTest(false)
@@ -110,18 +108,11 @@ public class Diary extends BaseEntityWithUpdate {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(validateCreateDiaryDate(diaryDate))
+            .diaryDate(diaryDate.atTime(LocalTime.now()))
             .notes(notes)
             .isAi(true)
             .isTest(true)
             .build();
-    }
-
-    private static LocalDateTime validateCreateDiaryDate(LocalDate diaryDate) {
-        if (diaryDate.isAfter(LocalDate.now())) {
-            throw new BusinessException(ErrorCode.INVALID_CREATE_DIARY_DATE);
-        }
-        return diaryDate.atTime(LocalTime.now());
     }
 
     public void setNotes(String notes) {

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -1,6 +1,8 @@
 package tipitapi.drawmytoday.diary.domain;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -22,6 +24,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.user.domain.User;
 
@@ -76,7 +80,7 @@ public class Diary extends BaseEntityWithUpdate {
     private boolean isTest;
 
     @Builder
-    public Diary(User user, Emotion emotion, LocalDateTime diaryDate, String notes, boolean isAi,
+    private Diary(User user, Emotion emotion, LocalDateTime diaryDate, String notes, boolean isAi,
         String title,
         String weather, ReviewType review, boolean isTest) {
         this.user = user;
@@ -89,6 +93,35 @@ public class Diary extends BaseEntityWithUpdate {
         this.review = review;
         this.isTest = isTest;
         this.imageList = new ArrayList<>();
+    }
+
+    public static Diary of(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+        return Diary.builder()
+            .user(user)
+            .emotion(emotion)
+            .diaryDate(validateCreateDiaryDate(diaryDate))
+            .notes(notes)
+            .isAi(true)
+            .isTest(false)
+            .build();
+    }
+
+    public static Diary ofTest(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+        return Diary.builder()
+            .user(user)
+            .emotion(emotion)
+            .diaryDate(validateCreateDiaryDate(diaryDate))
+            .notes(notes)
+            .isAi(true)
+            .isTest(true)
+            .build();
+    }
+
+    private static LocalDateTime validateCreateDiaryDate(LocalDate diaryDate) {
+        if (diaryDate.isAfter(LocalDate.now())) {
+            throw new BusinessException(ErrorCode.INVALID_CREATE_DIARY_DATE);
+        }
+        return diaryDate.atTime(LocalTime.now());
     }
 
     public void setNotes(String notes) {

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
@@ -23,6 +23,7 @@ public class CreateDiaryRequest {
     @Schema(description = "감정 ID")
     private Long emotionId;
 
+    @Size(max = 100)
     @Schema(description = "일기 키워드", nullable = true)
     private String keyword;
 

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.common.validator.ValidDiaryDate;
 
 @Getter
 @Schema(description = "일기 생성 Request")
@@ -22,7 +23,6 @@ public class CreateDiaryRequest {
     @Schema(description = "감정 ID")
     private Long emotionId;
 
-    @Size(max = 100)
     @Schema(description = "일기 키워드", nullable = true)
     private String keyword;
 
@@ -31,6 +31,7 @@ public class CreateDiaryRequest {
     private String notes;
 
     @NotNull
+    @ValidDiaryDate
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -2,13 +2,10 @@ package tipitapi.drawmytoday.diary.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import tipitapi.drawmytoday.common.exception.BusinessException;
-import tipitapi.drawmytoday.common.exception.ErrorCode;
 import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.dalle.exception.ImageInputStreamFailException;
@@ -48,9 +45,9 @@ public class CreateDiaryService {
         // TODO: 광고 추가시 일기 생성 제한 로직으로 변경 필요
         User user = validateUserService.validateUserWithDrawLimit(userId);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
-        validateCreateDiaryDate(diaryDate);
-        String prompt = promptTextService.createPromptText(emotion, keyword);
         String encryptedNotes = encryptor.encrypt(notes);
+        String prompt = promptTextService.createPromptText(emotion, keyword);
+        Diary diary = Diary.of(user, emotion, diaryDate, encryptedNotes);
 
         if (test) {
             return createDummyDiary(user, emotion, prompt, encryptedNotes, diaryDate);
@@ -59,11 +56,7 @@ public class CreateDiaryService {
         try {
             byte[] dallEImage = dallEService.getImageAsUrl(prompt);
 
-            Diary diary = diaryRepository.save(
-                Diary.builder().user(user).emotion(emotion)
-                    .diaryDate(diaryDate.atTime(LocalTime.now()))
-                    .notes(encryptedNotes)
-                    .isAi(true).isTest(false).build());
+            diaryRepository.save(diary);
             promptService.createPrompt(diary, prompt, true);
 
             String imagePath = getImagePath(diary.getDiaryId(), 1);
@@ -77,12 +70,6 @@ public class CreateDiaryService {
         }
     }
 
-    private void validateCreateDiaryDate(LocalDate diaryDate) {
-        if (diaryDate.isAfter(LocalDate.now())) {
-            throw new BusinessException(ErrorCode.INVALID_CREATE_DIARY_DATE);
-        }
-    }
-
     private String getImagePath(Long diaryId, int index) {
         return String.format("post/%d/%s_%d.png", diaryId,
             new Date().getTime(), index);
@@ -91,9 +78,7 @@ public class CreateDiaryService {
     private CreateDiaryResponse createDummyDiary(User user, Emotion emotion, String prompt,
         String notes, LocalDate diaryDate) {
         Diary diary = diaryRepository.save(
-            Diary.builder().user(user).emotion(emotion)
-                .diaryDate(diaryDate.atTime(LocalTime.now()))
-                .notes(notes).isAi(true).isTest(true).build());
+            Diary.ofTest(user, emotion, diaryDate, notes));
         promptService.createPrompt(diary, prompt, true);
         imageService.createImage(diary, DUMMY_IMAGE_PATH, true);
         user.setLastDiaryDate(LocalDateTime.now());

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -39,7 +39,7 @@ public class CreateDiaryService {
         noRollbackFor = {DallERequestFailException.class, DallERequestFailException.class,
             ImageInputStreamFailException.class})
     public CreateDiaryResponse createDiary(Long userId, Long emotionId, String keyword,
-        String notes, LocalDate diaryDate, boolean test)
+        String notes, LocalDate diaryDate)
         throws DallERequestFailException, ImageInputStreamFailException {
         // TODO: 이미지 여러 개로 요청할 경우의 핸들링 필요
         User user = validateUserService.validateUserWithDrawLimit(userId);
@@ -48,9 +48,6 @@ public class CreateDiaryService {
         String prompt = promptTextService.createPromptText(emotion, keyword);
         Diary diary = Diary.of(user, emotion, diaryDate, encryptedNotes);
 
-        if (test) {
-            return createDummyDiary(user, emotion, prompt, encryptedNotes, diaryDate);
-        }
 
         try {
             byte[] dallEImage = dallEService.getImageAsUrl(prompt);
@@ -74,7 +71,8 @@ public class CreateDiaryService {
             new Date().getTime(), index);
     }
 
-    private CreateDiaryResponse createDummyDiary(User user, Emotion emotion, String prompt,
+    @Transactional(readOnly = false)
+    public CreateDiaryResponse createTestDiary(Long userId, Long emotionId, String keyword,
         String notes, LocalDate diaryDate) {
         Diary diary = diaryRepository.save(
             Diary.ofTest(user, emotion, diaryDate, notes));

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -42,7 +42,6 @@ public class CreateDiaryService {
         String notes, LocalDate diaryDate, boolean test)
         throws DallERequestFailException, ImageInputStreamFailException {
         // TODO: 이미지 여러 개로 요청할 경우의 핸들링 필요
-        // TODO: 광고 추가시 일기 생성 제한 로직으로 변경 필요
         User user = validateUserService.validateUserWithDrawLimit(userId);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
         String encryptedNotes = encryptor.encrypt(notes);

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -48,7 +48,7 @@ public class CreateDiaryService {
 
             Diary diary = saveDiary(notes, user, emotion, diaryDate, false);
             promptService.createPrompt(diary, prompt, true);
-            imageService.uploadImage(diary, dallEImage, true);
+            imageService.uploadAndCreateImage(diary, dallEImage, true);
 
             return new CreateDiaryResponse(diary.getDiaryId());
         } catch (DallERequestFailException | ImageInputStreamFailException e) {

--- a/src/main/java/tipitapi/drawmytoday/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/ImageService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.diary.service;
 
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +8,7 @@ import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.repository.ImageRepository;
+import tipitapi.drawmytoday.s3.service.S3Service;
 
 @Service
 @Transactional(readOnly = true)
@@ -14,6 +16,7 @@ import tipitapi.drawmytoday.diary.repository.ImageRepository;
 public class ImageService {
 
     private final ImageRepository imageRepository;
+    private final S3Service s3Service;
 
     public Image getImage(Diary diary) {
         return imageRepository.findByIsSelectedTrueAndDiary(diary)
@@ -22,5 +25,12 @@ public class ImageService {
 
     public Image createImage(Diary diary, String imagePath, boolean isSelected) {
         return imageRepository.save(Image.create(diary, imagePath, isSelected));
+    }
+
+    public Image uploadImage(Diary diary, byte[] dallEImage, boolean isSelected) {
+        String imagePath = String.format("post/%d/%s_%d.png", diary.getDiaryId(),
+            new Date().getTime(), 1);
+        s3Service.uploadImage(dallEImage, imagePath);
+        return createImage(diary, imagePath, isSelected);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/ImageService.java
@@ -27,7 +27,7 @@ public class ImageService {
         return imageRepository.save(Image.create(diary, imagePath, isSelected));
     }
 
-    public Image uploadImage(Diary diary, byte[] dallEImage, boolean isSelected) {
+    public Image uploadAndCreateImage(Diary diary, byte[] dallEImage, boolean isSelected) {
         String imagePath = String.format("post/%d/%s_%d.png", diary.getDiaryId(),
             new Date().getTime(), 1);
         s3Service.uploadImage(dallEImage, imagePath);

--- a/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
@@ -37,10 +37,4 @@ public class PromptTextService {
         return sb.toString();
     }
 
-    private String validateKeywordSize(String keyword) {
-        if (keyword.length() > 100) {
-            return keyword.substring(0, 100);
-        }
-        return keyword;
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
@@ -37,4 +37,10 @@ public class PromptTextService {
         return sb.toString();
     }
 
+    private String validateKeywordSize(String keyword) {
+        if (keyword.length() > 100) {
+            return keyword.substring(0, 100);
+        }
+        return keyword;
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.common.testdata;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
@@ -9,13 +10,11 @@ import tipitapi.drawmytoday.user.domain.User;
 public class TestDiary {
 
     public static Diary createDiary(User user, Emotion emotion) {
-        return Diary.builder().user(user).emotion(emotion)
-            .diaryDate(LocalDateTime.now()).isAi(true).isTest(false).build();
+        return Diary.of(user, emotion, LocalDate.now(), null);
     }
 
     public static Diary createTestDiary(User user, Emotion emotion) {
-        return Diary.builder().user(user).emotion(emotion)
-            .diaryDate(LocalDateTime.now()).isAi(true).isTest(true).build();
+        return Diary.ofTest(user, emotion, LocalDate.now(), null);
     }
 
     public static Diary createDiaryWithId(Long diaryId, User user, Emotion emotion) {

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -1,7 +1,6 @@
 package tipitapi.drawmytoday.diary.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -233,6 +232,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 Map<String, Object> requestMap = new HashMap<>();
                 requestMap.put("keyword", keyword);
                 requestMap.put("notes", notes);
+                requestMap.put("diaryDate", diaryDate);
                 String requestBody = objectMapper.writeValueAsString(requestMap);
                 ResultActions result = mockMvc.perform(post(BASIC_URL)
                     .with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -242,8 +242,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
-                    anyBoolean());
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
             }
 
             @Test
@@ -256,6 +255,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 requestMap.put("emotionId", emotionId);
                 requestMap.put("keyword", overKeyword);
                 requestMap.put("notes", notes);
+                requestMap.put("diaryDate", diaryDate);
                 String requestBody = objectMapper.writeValueAsString(requestMap);
                 ResultActions result = mockMvc.perform(post(BASIC_URL)
                     .with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -265,8 +265,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
-                    anyBoolean());
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
             }
 
             @Test
@@ -279,6 +278,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 requestMap.put("emotionId", emotionId);
                 requestMap.put("keyword", keyword);
                 requestMap.put("notes", overNotes);
+                requestMap.put("diaryDate", diaryDate);
                 String requestBody = objectMapper.writeValueAsString(requestMap);
                 ResultActions result = mockMvc.perform(post(BASIC_URL)
                     .with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -288,8 +288,28 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
-                    anyBoolean());
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+            }
+
+            @Test
+            @DisplayName("diaryDate가 미래의 날짜라면 BAD_REQUEST 상태코드를 응답한다.")
+            void diaryDate_is_After_now() throws Exception {
+                // given
+                // when
+                Map<String, Object> requestMap = new HashMap<>();
+                requestMap.put("keyword", keyword);
+                requestMap.put("notes", notes);
+                requestMap.put("diaryDate", LocalDate.now().plusDays(1));
+                String requestBody = objectMapper.writeValueAsString(requestMap);
+                ResultActions result = mockMvc.perform(post(BASIC_URL)
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+                // then
+                result.andExpect(status().isBadRequest());
+                verify(createDiaryService, never()).createDiary(any(Long.class),
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
             }
         }
 
@@ -303,7 +323,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // given
                 Long diaryId = 1L;
                 given(createDiaryService.createDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, false))
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
                     .willReturn(new CreateDiaryResponse(diaryId));
 
                 // when
@@ -328,8 +348,8 @@ class DiaryControllerTest extends ControllerTestSetup {
             void true_than_create_test_diary() throws Exception {
                 // given
                 Long testDiaryId = 1L;
-                given(createDiaryService.createDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, true))
+                given(createDiaryService.createTestDiary(
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
                     .willReturn(new CreateDiaryResponse(testDiaryId));
 
                 // when

--- a/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.testdata.TestDiary;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.common.testdata.TestUser;
@@ -32,7 +31,6 @@ import tipitapi.drawmytoday.diary.dto.CreateDiaryResponse;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.emotion.service.ValidateEmotionService;
-import tipitapi.drawmytoday.s3.service.S3Service;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
 
@@ -50,8 +48,6 @@ class CreateDiaryServiceTest {
     @Mock
     private ValidateEmotionService validateEmotionService;
     @Mock
-    private S3Service s3Service;
-    @Mock
     private DallEService dallEService;
     @Mock
     private PromptService promptService;
@@ -68,97 +64,7 @@ class CreateDiaryServiceTest {
         private final Long EMOTION_ID = 1L;
         private final String KEYWORD = "키워드";
         private final String NOTES = "노트";
-        private final LocalDate CREATE_DIARY_DATE = LocalDate.now();
-        private final boolean NON_TEST = false;
-
-        @Nested
-        @DisplayName("파라미터로 받은 createDiaryDate가")
-        class Create_diary_date_param_is {
-
-            @Test
-            @DisplayName("오늘 이후의 날짜일 경우 BusinessException을 던진다")
-            void is_after_today_date_then_throw_exception() throws Exception {
-                //given
-                LocalDate afterCreateDiaryDate = CREATE_DIARY_DATE.plusDays(1L);
-
-                //when
-                //then
-                assertThatThrownBy(() -> createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, afterCreateDiaryDate, NON_TEST))
-                    .isInstanceOf(BusinessException.class);
-            }
-        }
-
-        @Nested
-        @DisplayName("파라미터로 받은 test가")
-        class Test_param_is {
-
-            @Test
-            @DisplayName("true일 경우 그림을 생성하지 않는다.")
-            void true_then_not_draw_image() throws Exception {
-                //given
-                boolean test = true;
-                Long diaryId = 1L;
-                User user = TestUser.createUserWithId(USER_ID);
-                LocalDateTime lastDateTime = CREATE_DIARY_DATE.minusDays(1L).atTime(1, 1);
-                user.setLastDiaryDate(lastDateTime);
-                Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
-                String prompt = "test prompt";
-                String encryptedNotes = "encrypted notes";
-                Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
-                given(validateUserService.validateUserWithDrawLimit(USER_ID)).willReturn(user);
-                given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
-                given(promptTextService.createPromptText(emotion, KEYWORD)).willReturn(prompt);
-                given(encryptor.encrypt(NOTES)).willReturn(encryptedNotes);
-                given(diaryRepository.save(any(Diary.class))).willReturn(diary);
-
-                //when
-                CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, CREATE_DIARY_DATE, test);
-
-                //then
-                assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
-                assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
-                verify(dallEService, never()).getImageAsUrl(any(String.class));
-                verify(s3Service, never()).uploadImage(any(byte[].class), any(String.class));
-                verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
-                verify(imageService).createImage(eq(diary), any(String.class), eq(true));
-            }
-
-            @Test
-            @DisplayName("false일 경우 그림을 생성한다.")
-            void false_then_draw_image() throws Exception {
-                //given
-                boolean test = false;
-                Long diaryId = 1L;
-                User user = TestUser.createUserWithId(USER_ID);
-                LocalDateTime lastDateTime = CREATE_DIARY_DATE.minusDays(1L).atTime(1, 1);
-                user.setLastDiaryDate(lastDateTime);
-                Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
-                String prompt = "test prompt";
-                String encryptedNotes = "encrypted notes";
-                byte[] image = new byte[1];
-                Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
-                given(validateUserService.validateUserWithDrawLimit(USER_ID)).willReturn(user);
-                given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
-                given(promptTextService.createPromptText(emotion, KEYWORD)).willReturn(prompt);
-                given(encryptor.encrypt(NOTES)).willReturn(encryptedNotes);
-                given(dallEService.getImageAsUrl(prompt)).willReturn(image);
-                given(diaryRepository.save(any(Diary.class))).willReturn(diary);
-
-                //when
-                CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, CREATE_DIARY_DATE, test);
-
-                //then
-                assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
-                assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
-                verify(dallEService).getImageAsUrl(any(String.class));
-                verify(s3Service).uploadImage(eq(image), any(String.class));
-                verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
-                verify(imageService).createImage(eq(diary), any(String.class), eq(true));
-            }
-        }
+        private final LocalDate DIARY_DATE = LocalDate.now();
 
         @Nested
         @DisplayName("dallE 요청 시")
@@ -172,10 +78,11 @@ class CreateDiaryServiceTest {
                 throws Exception {
                 //given
                 User user = TestUser.createUserWithId(USER_ID);
-                LocalDateTime lastDateTime = CREATE_DIARY_DATE.minusDays(1L).atTime(1, 1);
+                LocalDateTime lastDateTime = DIARY_DATE.minusDays(1L).atTime(1, 1);
                 user.setLastDiaryDate(lastDateTime);
                 Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
                 String prompt = "test prompt";
+
                 given(validateUserService.validateUserWithDrawLimit(USER_ID)).willReturn(user);
                 given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
                 given(promptTextService.createPromptText(emotion, KEYWORD)).willReturn(prompt);
@@ -183,13 +90,91 @@ class CreateDiaryServiceTest {
 
                 //when
                 //then
-                assertThatThrownBy(() -> createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, CREATE_DIARY_DATE, NON_TEST))
-                    .isInstanceOf(exceptionClass);
+                assertThatThrownBy(
+                    () -> createDiaryService.createDiary(USER_ID, EMOTION_ID, KEYWORD, NOTES,
+                        DIARY_DATE)).isInstanceOf(exceptionClass);
                 assertThat(user.getLastDiaryDate().isEqual(lastDateTime)).isTrue();
+
                 verify(promptService).createPrompt(eq(prompt), eq(false));
                 verify(promptService, never()).createPrompt(any(Diary.class), eq(prompt), eq(true));
             }
+
+            @Test
+            @DisplayName("정상일 경우 일기를 생성한다.")
+            void success_then_create_diary() throws Exception {
+                //given
+                Long diaryId = 1L;
+                LocalDateTime lastDateTime = DIARY_DATE.minusDays(1L).atTime(1, 1);
+                String prompt = "test prompt";
+                byte[] image = new byte[1];
+
+                User user = TestUser.createUserWithId(USER_ID);
+                user.setLastDiaryDate(lastDateTime);
+                Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
+                Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
+
+                given(validateUserService.validateUserWithDrawLimit(USER_ID)).willReturn(user);
+                given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
+                given(promptTextService.createPromptText(emotion, KEYWORD)).willReturn(prompt);
+                given(dallEService.getImageAsUrl(prompt)).willReturn(image);
+                given(encryptor.encrypt(NOTES)).willReturn("암호화된 노트");
+                given(diaryRepository.save(any(Diary.class))).willReturn(diary);
+
+                //when
+                CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
+                    USER_ID, EMOTION_ID, KEYWORD, NOTES, DIARY_DATE);
+
+                //then
+                assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
+                assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
+
+                verify(dallEService).getImageAsUrl(any(String.class));
+                verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
+                verify(imageService).uploadImage(eq(diary), any(byte[].class), eq(true));
+            }
         }
     }
+
+    @Nested
+    @DisplayName("createTestDiary 메서드는")
+    class Create_test_diary_test {
+
+        @Test
+        @DisplayName("그림을 생성하지 않는다.")
+        void not_draw_image() throws Exception {
+            //given
+            Long userId = 1L;
+            LocalDate diaryDate = LocalDate.now();
+            Long emotionId = 1L;
+            Long diaryId = 1L;
+            String prompt = "test prompt";
+            String notes = "노트";
+            String keyword = "키워드";
+            LocalDateTime lastDateTime = diaryDate.minusDays(1L).atTime(1, 1);
+
+            User user = TestUser.createUserWithId(userId);
+            user.setLastDiaryDate(lastDateTime);
+            Emotion emotion = TestEmotion.createEmotionWithId(emotionId);
+            Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
+
+            given(validateUserService.validateUserWithDrawLimit(userId)).willReturn(user);
+            given(validateEmotionService.validateEmotionById(emotionId)).willReturn(emotion);
+            given(encryptor.encrypt(notes)).willReturn("암호화된 노트");
+            given(diaryRepository.save(any(Diary.class))).willReturn(diary);
+            given(promptTextService.createPromptText(emotion, keyword)).willReturn(prompt);
+
+            //when
+            CreateDiaryResponse response = createDiaryService.createTestDiary(
+                userId, emotionId, keyword, notes, diaryDate);
+
+            //then
+            assertThat(response.getId()).isEqualTo(diaryId);
+            assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
+
+            verify(dallEService, never()).getImageAsUrl(any(String.class));
+            verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
+            verify(imageService).createImage(eq(diary), any(String.class), eq(true));
+        }
+    }
+
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
@@ -130,7 +130,7 @@ class CreateDiaryServiceTest {
 
                 verify(dallEService).getImageAsUrl(any(String.class));
                 verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
-                verify(imageService).uploadImage(eq(diary), any(byte[].class), eq(true));
+                verify(imageService).uploadAndCreateImage(eq(diary), any(byte[].class), eq(true));
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/ImageServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/ImageServiceTest.java
@@ -2,8 +2,12 @@ package tipitapi.drawmytoday.diary.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiary;
+import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
 import static tipitapi.drawmytoday.common.testdata.TestImage.createImageWithId;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
@@ -20,12 +24,15 @@ import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.diary.domain.Image;
 import tipitapi.drawmytoday.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.diary.repository.ImageRepository;
+import tipitapi.drawmytoday.s3.service.S3Service;
 
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
 
     @Mock
     ImageRepository imageRepository;
+    @Mock
+    S3Service s3Service;
     @InjectMocks
     ImageService imageService;
 
@@ -67,6 +74,54 @@ class ImageServiceTest {
                 assertThatThrownBy(() -> imageService.getImage(diary))
                     .isInstanceOf(ImageNotFoundException.class);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("createImage 메서드는")
+    class CreateImageTest {
+
+        @Test
+        @DisplayName("이미지를 생성한다.")
+        void it_creates_image() {
+            // given
+            Diary diary = createDiary(createUser(), createEmotion());
+            Image image = createImageWithId(1L, diary);
+
+            given(imageRepository.save(any(Image.class))).willReturn(image);
+
+            // when
+            Image createdImage = imageService.createImage(diary, "post/1/1234_1.png", true);
+
+            // then
+            assertThat(createdImage).isEqualTo(image);
+
+            verify(imageRepository).save(any(Image.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadImage 메서드는")
+    class UploadImageTest {
+
+        @Test
+        @DisplayName("이미지를 업로드하고 생성한다")
+        void it_uploads_and_creates_image() {
+            // given
+            Long diaryId = 1L;
+            Diary diary = createDiaryWithId(diaryId, createUser(), createEmotion());
+            Image image = createImageWithId(1L, diary);
+            String imagePathRegex = "post/" + diaryId + "/\\d+_1.png";
+
+            given(imageRepository.save(any(Image.class))).willReturn(image);
+
+            // when
+            Image createdImage = imageService.uploadImage(diary, new byte[1], true);
+
+            // then
+            assertThat(createdImage).isEqualTo(image);
+            verify(s3Service).uploadImage(any(byte[].class), matches(imagePathRegex));
+            verify(imageRepository).save(any(Image.class));
         }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/ImageServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/ImageServiceTest.java
@@ -101,8 +101,8 @@ class ImageServiceTest {
     }
 
     @Nested
-    @DisplayName("uploadImage 메서드는")
-    class UploadImageTest {
+    @DisplayName("uploadAndCreateImage 메서드는")
+    class UploadAndCreateImageTest {
 
         @Test
         @DisplayName("이미지를 업로드하고 생성한다")
@@ -116,7 +116,7 @@ class ImageServiceTest {
             given(imageRepository.save(any(Image.class))).willReturn(image);
 
             // when
-            Image createdImage = imageService.uploadImage(diary, new byte[1], true);
+            Image createdImage = imageService.uploadAndCreateImage(diary, new byte[1], true);
 
             // then
             assertThat(createdImage).isEqualTo(image);

--- a/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
@@ -28,7 +28,7 @@ class PromptTextServiceTest {
         class KeywordIs {
 
             @Test
-            @DisplayName("null이면 keyword 자리에 emotional을 넣어 반환한다.")
+            @DisplayName("null이면 keyword 자리에 emotions을 넣어 반환한다.")
             void nullThanAddEmotional() throws Exception {
                 //given
                 Emotion emotion = TestEmotion.createEmotion();
@@ -37,12 +37,12 @@ class PromptTextServiceTest {
                 String promptText = promptTextService.createPromptText(emotion, keyword);
 
                 //then
-                assertThat(promptText).contains("emotional");
+                assertThat(promptText).contains("emotions");
             }
 
             @ParameterizedTest
             @ValueSource(strings = {"", " ", "  "})
-            @DisplayName("비어있으면 keyword 자리에 emotional을 넣어 반환한다.")
+            @DisplayName("비어있으면 keyword 자리에 emotions을 넣어 반환한다.")
             void emptyThanAddEmotional(String keyword) throws Exception {
                 //given
                 Emotion emotion = TestEmotion.createEmotion();
@@ -51,7 +51,7 @@ class PromptTextServiceTest {
                 String promptText = promptTextService.createPromptText(emotion, keyword);
 
                 //then
-                assertThat(promptText).contains("emotional");
+                assertThat(promptText).contains("emotions");
             }
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

=> `[POST] /diary` 일기 생성 API와 관련된 `diaryDate` 필드 검증 방식 변경, 코드 아키텍처 리팩토링

### `diaryDate` 필드에 대한 검증을 DTO Validation 단계에서 처리하도록 개선
- `diaryDate`가 미래의 날짜인기 검증하는 Custom 어노테이션 `ValidDiaryDate` 와 그 Validator 클래스인 `DiaryDateValidator` 추가
- 기존의 `createDiary`에서 `diaryDate`를 검증하던 `validateCreateDiaryDate` 메소드 삭제

### Diary 생성 메소드 추가
- CreateDiaryService와 기타 테스트 코드 등 여러 코드에서 일기 객체를 생성하는 로직이 필요함
- 기존에는 `빌더 패턴`으로 일기 객체를 생성했는데, 이는 각 파라미터를 매우 자율적으로 조정가능하므로, 일기의 객체의 유형이 변경되거나 파라미터가 변경되었을때 빌더 패턴을 사용한 모든 것의 변경이 수반됨
- 이를 개선하고자 일기 객체를 생성하는 메소드를 추가하였음
- 현재 비즈니스 로직상, 테스트용 일기와 일반 일기를 생성하는 두 경우로 나뉘므로 두개의 객체 생성 메소드 `of`, `ofTest`를 Diary 도메인 클래스에 추가함
- 이를 통해, 
  - 일기를 생성할때 각 유형으로 획일화 되어 어디서든 생성할 수 있고
  - 일기를 생성할때 isAi 필드와 같이 자율적으로 조정하는 행위를 도메인의 책임으로 이동시켰고
  - 일기 생성시에 세부적인 로직이 변경되어도 도메인 코드만 수정할 수 있는 
이점을 취할 수 있음

### 테스트 용 일기 생성 메소드 분리
- 기존에는 일기 생성 API 요청시 `CreateDiaryService.createDiary` 메소드에서 모든 요청을 받아 test ( boolean ) 변수값에 따라 if문으로 내부 `createDummyDiary` 메소드를 호출함
- 하지만, 
  - 테스트용 일기는 비즈니스 로직 확장에 따라 추가적인 요청이 확장될 가능성이 있고, 
  - 쿼리 파라미터 test하나로 테스트 생성 여부를 판단하므로 
  - API 요청이 조작될 경우 일반 일기 생성 요청으로 변경되는 등 
- 현재의 구조는 취약하다는 문제점이 있음
- 이를 위해 **테스트용 일기 생성은 별도의 API로 분리되는 것이 맞지만** 클라이언트 측과 논의가 필요함 ( #137 )
- 따라서 유지보수와 가독성 측면을 고려하여, 기존의 CreateDiaryService.createDiary에서 모든 일기 생성 요청을 받아 다른 메소드를 호출하는 방식에서, **컨트롤러 단에서 별도의 `CreateDiaryService.createTestDiary `메소드로 요청하도록 분리함**
- 일기를 생성하는 과정에서 일반 일기과 테스트 일기가 동일한 플로우를 가지는 부분은 메서드화하여 유지보수성을 높였음 ( -> `saveDiary` 메서드. 하단에서 기술함 )

### 일기 생성시 이미지와 관련된 작업은 `ImageService`에서 처리하도록 로직 이동
- 현재 일기 생성시, 
  1. 이미지 경로 String 생성
  2. s3 이미지 업로드
  3. 이미지 객체 생성 후 저장
의 **이미지와 관련된 과정**이 수반되는데, 이는 `ImageService`가 책임을 져야하는 행위로 간주됨
- 따라서, 이 로직을 `ImageService`의 `uploadImage` 메서드를 생성하여 이관시킴
- 단, 테스트용 일기 생성시 s3로 업로드하지 않고 이미지 객체를 생성해 저장하는 작업만 수행하므로, 이때는 `ImageService.createImage` 메소드를 호출하도록 함

### 일기 생성시 일기 데이터 자체를 생성하는데 필요한 과정 메서드화
- `createDiary` 메서드에서는 일기를 생성할때 아래와 같은 과정을 거침
  0. 필요한 객체 조회, 검증 - `User`, `Emotion` 등
  1. 일기 내용 `notes` 암호화
  2. `DALL E`로 이미지 생성 요청 ( 일반 일기 생성시 )
  3. 일기 객체를 생성
  4. 프롬프트 객체를 생성
  5. 일기 객체를 생성, 업로드 - `ImageService.createImage` / `ImageService.uploadImage` ( 테스트 일기 생성시 )
  6. 유저 `lastDiaryDate` 변경
- 이때, Diary 도메인 자체에 책임이 있는 과정, 즉 **_Diary 객체가 생성되는 것만으로도 묶일 수 있는 작업_**은 일기 내용 암호화 / 일기 객체 생성 / 유저 lastDiaryDate 변경 과정임
- 따라서 이를 별도의 메서드 `saveDiary`에서 처리하도록 변경함
- 이를 통해 
  - 일기를 생성하는 플로우의 가독성을 높였고, 
  - 테스트 일기 생성시에도 동일한 과정이 수반됨에 따라 불필요한 코드를 메서드로 모듈화함(재사용성 증가)

### 키워드 없이 감정만으로 일기 프롬프트 생성시, emotions값을 넣는 코드의 테스트 코드 변경 반영 
- #140 에 대한 작업에, 테스트 코드 변경이 반영되지 않아 이 PR에서 반영해두었음

## 관련 이슈

close #131 
close #140

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
