### PR TITLE
일기 프롬프트 생성시 keyword가 100자를 넘을 경우 자르도록 처리

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
@@ -22,8 +22,7 @@ public class CreateDiaryRequest {
     @NotNull
     @Schema(description = "감정 ID")
     private Long emotionId;
-
-    @Size(max = 100)
+    
     @Schema(description = "일기 키워드", nullable = true)
     private String keyword;
 

--- a/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/PromptTextService.java
@@ -12,6 +12,8 @@ public class PromptTextService {
     public String createPromptText(Emotion emotion, String keyword) {
         if (!StringUtils.hasText(keyword)) {
             keyword = "emotions";
+        } else {
+            keyword = validateKeywordSize(keyword);
         }
         return promptTextBuilder(
             emotion.getEmotionPrompt(),
@@ -37,4 +39,10 @@ public class PromptTextService {
         return sb.toString();
     }
 
+    private String validateKeywordSize(String keyword) {
+        if (keyword.length() > 100) {
+            return keyword.substring(0, 100);
+        }
+        return keyword;
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -246,29 +246,6 @@ class DiaryControllerTest extends ControllerTestSetup {
             }
 
             @Test
-            @DisplayName("keyword 값이 100byte가 넘는다면 BAD_REQUEST 상태코드를 응답한다.")
-            void keyword_is_null_than_return_bad_request() throws Exception {
-                // given
-                // when
-                String overKeyword = "a".repeat(101);
-                Map<String, Object> requestMap = new HashMap<>();
-                requestMap.put("emotionId", emotionId);
-                requestMap.put("keyword", overKeyword);
-                requestMap.put("notes", notes);
-                requestMap.put("diaryDate", diaryDate);
-                String requestBody = objectMapper.writeValueAsString(requestMap);
-                ResultActions result = mockMvc.perform(post(BASIC_URL)
-                    .with(SecurityMockMvcRequestPostProcessors.csrf())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody));
-
-                // then
-                result.andExpect(status().isBadRequest());
-                verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
-            }
-
-            @Test
             @DisplayName("notes 값이 6010byte가 넘는다면 BAD_REQUEST 상태코드를 응답한다.")
             void notes_is_null_than_return_bad_request() throws Exception {
                 // given

--- a/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/PromptTextServiceTest.java
@@ -53,6 +53,23 @@ class PromptTextServiceTest {
                 //then
                 assertThat(promptText).contains("emotions");
             }
+
+            @Test
+            @DisplayName("키워드가 100자를 초과할 경우 100자로 자른다.")
+            void over100CharThanSubstring() throws Exception {
+                //given
+                Emotion emotion = TestEmotion.createEmotion();
+                String keyword_over_max = "a".repeat(101);
+                String keyword_not_over_max = "a".repeat(100);
+
+                //when
+                String promptText = promptTextService.createPromptText(emotion, keyword_over_max);
+
+                //then
+                assertThat(promptText).isEqualTo(
+                    emotion.getEmotionPrompt() + ", " + emotion.getColorPrompt() + ", "
+                        + "canvas-textured, Oil Pastel, " + keyword_not_over_max);
+            }
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

일기 프롬프트 생성시 keyword가 100자를 넘을 경우 자르도록 처리
- 기존에는 keyword 필드를 DTO validation을 통해 최대 100자로 검증하였음
- 하지만, 앱에서 에러로 핸들링하기보다 서버 측에서 100자로 자르는 것이 비즈니스 로직상 적합한 것으로 논의됨에 따라, DTO Validation을 없애고 프롬프트 값을 생성할때 keyword의 길이를 100자 이하로 자르도록 처리함

## 관련 이슈

close #135 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
