### PR TITLE
일기 조회 api에 lan 쿼리 파라미터 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
@@ -3,8 +3,10 @@ package tipitapi.drawmytoday.common.config;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import tipitapi.drawmytoday.common.converter.StringToLanguageConverter;
 import tipitapi.drawmytoday.common.resolver.AuthUserArgumentResolver;
 
 @Configuration
@@ -12,9 +14,15 @@ import tipitapi.drawmytoday.common.resolver.AuthUserArgumentResolver;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthUserArgumentResolver authUserArgumentResolver;
+    private final StringToLanguageConverter stringToLanguageConverter;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authUserArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(stringToLanguageConverter);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/converter/Language.java
+++ b/src/main/java/tipitapi/drawmytoday/common/converter/Language.java
@@ -1,0 +1,5 @@
+package tipitapi.drawmytoday.common.converter;
+
+public enum Language {
+    ko, en
+}

--- a/src/main/java/tipitapi/drawmytoday/common/converter/StringToLanguageConverter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/converter/StringToLanguageConverter.java
@@ -1,0 +1,15 @@
+package tipitapi.drawmytoday.common.converter;
+
+
+import java.util.Objects;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToLanguageConverter implements Converter<String, Language> {
+
+    @Override
+    public Language convert(String source) {
+        return Objects.equals(source, "en") ? Language.en : Language.ko;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
@@ -63,11 +64,13 @@ public class DiaryController {
     })
     @GetMapping("/{id}")
     public ResponseEntity<SuccessResponse<GetDiaryResponse>> getDiary(
-        @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId
+        @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId,
+        @Parameter(description = "감정 반환 언어(ko/en)", in = ParameterIn.QUERY)
+        @RequestParam(name = "lan", required = false, defaultValue = "ko") Language language
         , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            diaryService.getDiary(tokenInfo.getUserId(), diaryId)
+            diaryService.getDiary(tokenInfo.getUserId(), diaryId, language)
         ).asHttp(HttpStatus.OK);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import tipitapi.drawmytoday.diary.domain.Diary;
-import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 @Getter
 @Schema(description = "일기 상세 Response")
@@ -45,9 +44,9 @@ public class GetDiaryResponse {
     @Schema(description = "프롬프트", requiredMode = RequiredMode.NOT_REQUIRED)
     private String prompt;
 
-    public static GetDiaryResponse of(Diary diary, String imageUrl, Emotion emotion,
+    public static GetDiaryResponse of(Diary diary, String imageUrl, String emotionText,
         String promptText) {
         return new GetDiaryResponse(diary.getDiaryId(), imageUrl, diary.getDiaryDate(),
-            diary.getCreatedAt(), emotion.getName(), diary.getNotes(), promptText);
+            diary.getCreatedAt(), emotionText, diary.getNotes(), promptText);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.adreward.domain.AdReward;
 import tipitapi.drawmytoday.adreward.service.ValidateAdRewardService;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.entity.BaseEntity;
 import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.common.utils.Encryptor;
@@ -40,7 +41,7 @@ public class DiaryService {
     private final ValidateDiaryService validateDiaryService;
     private final ValidateAdRewardService validateAdRewardService;
 
-    public GetDiaryResponse getDiary(Long userId, Long diaryId) {
+    public GetDiaryResponse getDiary(Long userId, Long diaryId, Language language) {
         User user = validateUserService.validateUserById(userId);
 
         Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
@@ -49,10 +50,12 @@ public class DiaryService {
         String imageUrl = s3PreSignedService.getPreSignedUrlForShare(
             imageService.getImage(diary).getImageUrl(), 30);
 
+        String emotionText = diary.getEmotion().getEmotionText(language);
+
         Optional<Prompt> prompt = promptService.getPromptByDiaryId(diaryId);
         String promptText = prompt.map(Prompt::getPromptText).orElse(null);
 
-        return GetDiaryResponse.of(diary, imageUrl, diary.getEmotion(), promptText);
+        return GetDiaryResponse.of(diary, imageUrl, emotionText, promptText);
     }
 
     public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, int year, int month) {

--- a/src/main/java/tipitapi/drawmytoday/emotion/domain/Emotion.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/domain/Emotion.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.entity.BaseEntity;
 
 @Getter
@@ -52,5 +53,9 @@ public class Emotion extends BaseEntity {
     public static Emotion create(String name, String color, boolean isActive, String emotionPrompt,
         String colorPrompt) {
         return new Emotion(name, color, isActive, emotionPrompt, colorPrompt);
+    }
+
+    public String getEmotionText(Language language) {
+        return language == Language.ko ? name : emotionPrompt;
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.ResultActions;
 import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
 import tipitapi.drawmytoday.common.controller.WithCustomUser;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.testdata.TestDiary;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.common.testdata.TestUser;
@@ -73,13 +74,17 @@ class DiaryControllerTest extends ControllerTestSetup {
                 long diaryId = 1L;
                 User user = TestUser.createUser();
                 Emotion emotion = TestEmotion.createEmotion();
+                Language language = Language.ko;
+                String emotionText = emotion.getEmotionText(language);
                 Diary diary = TestDiary.createDiaryWithIdAndCreatedAt(
                     diaryId, LocalDateTime.now(), user, emotion);
                 String imageUrl = "imageUrl";
                 String promptText = "promptText";
-                GetDiaryResponse getDiaryResponse = GetDiaryResponse.of(diary, imageUrl, emotion,
+                GetDiaryResponse getDiaryResponse = GetDiaryResponse.of(diary, imageUrl,
+                    emotionText,
                     promptText);
-                given(diaryService.getDiary(REQUEST_USER_ID, diaryId)).willReturn(getDiaryResponse);
+                given(diaryService.getDiary(REQUEST_USER_ID, diaryId, language)).willReturn(
+                    getDiaryResponse);
 
                 // when
                 ResultActions result = mockMvc.perform(get(BASIC_URL + "/" + diaryId));
@@ -92,7 +97,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                         parseLocalDateTime(diary.getDiaryDate())))
                     .andExpect(jsonPath("$.data.createdAt").value(
                         parseLocalDateTime(diary.getCreatedAt())))
-                    .andExpect(jsonPath("$.data.emotion").value(emotion.getName()))
+                    .andExpect(jsonPath("$.data.emotion").value(emotionText))
                     .andExpect(jsonPath("$.data.notes").value(diary.getNotes()))
                     .andExpect(jsonPath("$.data.prompt").value(promptText));
             }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- GET "/diary/{id}" api에 lan 쿼리 파라미터 추가
  - 쿼리 파라미터를 받을 Language enum 추가
  - String 타입 lan을 Language enum으로 변환할 Converter 추가
  - lan 값이 ko면 response dto의 emotion 필드에 emotion 엔티티의 name을, en이면 emotionPrompt를 반환
- getDiary 메서드 시그니처 변경으로 인해 달라진 테스트 코드 수정

## 논의사항

lan 쿼리 파라미터를 String 값으로 받아도 되지만 Language enum을 도입한 이유는 앞으로 다국어 지원이 도입됨에 따라 쿼리 파라미터에 lan을 받는 api들이 많아질 것 같기에 lan 쿼리 파라미터에 대한 검증과 값을 추상화하기 위해서 입니다.

만약 해당 구현이 괜찮으시다면 모든 감정을 반환하는 api도 lan 쿼리 파라미터를 Language로 받도록 수정하겠습니다!

## 관련 이슈

close #146 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
