### PR TITLE
prompt 테이블의 prompt_text 필드와 emotion 테이블의 color_prompt 필드의 최대 길이 증가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Prompt.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Prompt.java
@@ -28,7 +28,7 @@ public class Prompt extends BaseEntity {
     private Diary diary;
 
     @NotNull
-    @Column(length = 300)
+    @Column(length = 1100)
     private String promptText;
 
     @NotNull

--- a/src/main/java/tipitapi/drawmytoday/emotion/domain/Emotion.java
+++ b/src/main/java/tipitapi/drawmytoday/emotion/domain/Emotion.java
@@ -38,7 +38,7 @@ public class Emotion extends BaseEntity {
     private String emotionPrompt;
 
     @NotNull
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 200)
     private String colorPrompt;
 
     private Emotion(String name, String color, boolean isActive, String emotionPrompt,


### PR DESCRIPTION
# 구현 내용

## 구현 요약
- emotion 테이블의 color_prompt 필드 길이 변경
   - 30byte -> 200 byte 으로 변경
prompt 테이블의 prompt_text 필드 길이 변경
   - 300byte -> 1100 byte 으로 변경

데이터베이스의 아래와 같은 DDL을 수행해, 각 필드의 최대 길이를 변경해야합니다.
```sql
ALTER TABLE `draw_my_today_db`.`emotion`
CHANGE `color_prompt` `color_prompt` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
ALTER TABLE `draw_my_today_db`.`prompt`
CHANGE `prompt_text` `prompt_text` varchar(1100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL;
```

## 관련 이슈

close #157 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
