### PR TITLE
[글로벌 지원] 일기 조회 api response에 날짜 정보 UTC 반환

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntity.java
+++ b/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntity.java
@@ -1,6 +1,8 @@
 package tipitapi.drawmytoday.common.entity;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -18,4 +20,8 @@ public abstract class BaseEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public ZonedDateTime getCreatedAtWithZone() {
+        return createdAt.atZone(ZoneOffset.UTC);
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntityWithUpdate.java
+++ b/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntityWithUpdate.java
@@ -1,8 +1,6 @@
 package tipitapi.drawmytoday.common.entity;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -20,8 +18,4 @@ public abstract class BaseEntityWithUpdate extends BaseEntity {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
-
-    public ZonedDateTime getUpdatedAtWithZone() {
-        return updatedAt.atZone(ZoneOffset.UTC);
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntityWithUpdate.java
+++ b/src/main/java/tipitapi/drawmytoday/common/entity/BaseEntityWithUpdate.java
@@ -1,6 +1,8 @@
 package tipitapi.drawmytoday.common.entity;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -18,4 +20,8 @@ public abstract class BaseEntityWithUpdate extends BaseEntity {
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    public ZonedDateTime getUpdatedAtWithZone() {
+        return updatedAt.atZone(ZoneOffset.UTC);
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -3,6 +3,8 @@ package tipitapi.drawmytoday.diary.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -117,5 +119,9 @@ public class Diary extends BaseEntityWithUpdate {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public ZonedDateTime getDiaryDateWithZone() {
+        return this.diaryDate.atZone(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryResponse.java
@@ -1,13 +1,11 @@
 package tipitapi.drawmytoday.diary.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import tipitapi.drawmytoday.diary.domain.Diary;
@@ -23,17 +21,15 @@ public class GetDiaryResponse {
     @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
     private final String imageUrl;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonSerialize(using = ZonedDateTimeSerializer.class)
     @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
-    private final LocalDateTime date;
+    private final ZonedDateTime date;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonSerialize(using = ZonedDateTimeSerializer.class)
     @Schema(description = "일기 작성 시간", requiredMode = RequiredMode.REQUIRED)
-    private final LocalDateTime createdAt;
+    private final ZonedDateTime createdAt;
 
     @Schema(description = "감정", requiredMode = RequiredMode.REQUIRED)
     private final String emotion;
@@ -46,7 +42,7 @@ public class GetDiaryResponse {
 
     public static GetDiaryResponse of(Diary diary, String imageUrl, String emotionText,
         String promptText) {
-        return new GetDiaryResponse(diary.getDiaryId(), imageUrl, diary.getDiaryDate(),
-            diary.getCreatedAt(), emotionText, diary.getNotes(), promptText);
+        return new GetDiaryResponse(diary.getDiaryId(), imageUrl, diary.getDiaryDateWithZone(),
+            diary.getCreatedAtWithZone(), emotionText, diary.getNotes(), promptText);
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -93,10 +93,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 result.andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.id").value(diaryId))
                     .andExpect(jsonPath("$.data.imageUrl").value(imageUrl))
-                    .andExpect(jsonPath("$.data.date").value(
-                        parseLocalDateTime(diary.getDiaryDate())))
-                    .andExpect(jsonPath("$.data.createdAt").value(
-                        parseLocalDateTime(diary.getCreatedAt())))
+                    .andExpect(jsonPath("$.data.date").exists())
+                    .andExpect(jsonPath("$.data.createdAt").exists())
                     .andExpect(jsonPath("$.data.emotion").value(emotionText))
                     .andExpect(jsonPath("$.data.notes").value(diary.getNotes()))
                     .andExpect(jsonPath("$.data.prompt").value(promptText));

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -84,7 +84,8 @@ class DiaryServiceTest {
             @DisplayName("일기를 반환한다.")
             void it_returns_diary() {
                 User user = createUserWithId(1L);
-                Diary diary = createDiaryWithId(1L, user, createEmotion());
+                Diary diary = createDiaryWithIdAndCreatedAt(1L, LocalDateTime.now(), user,
+                    createEmotion());
                 Image image = createImage(diary);
                 Language language = Language.ko;
 
@@ -107,7 +108,7 @@ class DiaryServiceTest {
             void if_lan_en_then_return_emotionPrompt() {
                 User user = createUserWithId(1L);
                 Emotion emotion = createEmotion();
-                Diary diary = createDiaryWithId(1L, user, emotion);
+                Diary diary = createDiaryWithIdAndCreatedAt(1L, LocalDateTime.now(), user, emotion);
                 Image image = createImage(diary);
 
                 Language language = Language.en;
@@ -131,7 +132,7 @@ class DiaryServiceTest {
             void if_lan_ko_then_return_name() {
                 User user = createUserWithId(1L);
                 Emotion emotion = createEmotion();
-                Diary diary = createDiaryWithId(1L, user, emotion);
+                Diary diary = createDiaryWithIdAndCreatedAt(1L, LocalDateTime.now(), user, emotion);
                 Image image = createImage(diary);
 
                 Language language = Language.ko;


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- BaseEntity, Diary 엔티티의 createAt, diaryDate에 UTC 타임존 정보를 포함하여 반환하는 getter 추가
- GetDiaryResponse의 일기 날짜, 일기 작성 시간 반환할 때 타임존 정보 추가
- 테스트 수정

## 관련 이슈

close #165 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
