### PR TITLE
[글로벌 지원] 월별 일기 목록 api 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import tipitapi.drawmytoday.common.converter.StringToLanguageConverter;
+import tipitapi.drawmytoday.common.converter.StringToZoneIdConverter;
 import tipitapi.drawmytoday.common.resolver.AuthUserArgumentResolver;
 
 @Configuration
@@ -15,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthUserArgumentResolver authUserArgumentResolver;
     private final StringToLanguageConverter stringToLanguageConverter;
+    private final StringToZoneIdConverter stringToZoneOffsetConverter;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -24,5 +26,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(stringToLanguageConverter);
+        registry.addConverter(stringToZoneOffsetConverter);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/converter/StringToZoneIdConverter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/converter/StringToZoneIdConverter.java
@@ -1,0 +1,19 @@
+package tipitapi.drawmytoday.common.converter;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToZoneIdConverter implements Converter<String, ZoneId> {
+
+    @Override
+    public ZoneId convert(String source) {
+        try {
+            return ZoneId.of(source);
+        } catch (DateTimeException e) {
+            return ZoneId.of("Asia/Seoul");
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -1,8 +1,11 @@
 package tipitapi.drawmytoday.common.utils;
 
 import java.sql.Date;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -17,9 +20,23 @@ public class DateUtils {
         return LocalDateTime.of(year, month, 1, 0, 0, 0);
     }
 
+    public static LocalDateTime getStartDate(ZoneId timezone, int year, int month) {
+        validateMonth(month);
+        Instant startDate = LocalDateTime.of(year, month, 1, 0, 0, 0)
+            .toInstant(ZoneOffset.UTC);
+        return LocalDateTime.ofInstant(startDate, timezone);
+    }
+
     public static LocalDateTime getEndDate(int year, int month) {
         validateMonth(month);
         return LocalDateTime.of(year, month, getMaxDay(month), 23, 59);
+    }
+
+    public static LocalDateTime getEndDate(ZoneId timezone, int year, int month) {
+        validateMonth(month);
+        Instant endDate = LocalDateTime.of(year, month, getMaxDay(month), 23, 59, 59)
+            .toInstant(ZoneOffset.UTC);
+        return LocalDateTime.ofInstant(endDate, timezone);
     }
 
     public static Date getDate(int year, int month, int day) {

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.time.ZoneId;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -91,11 +92,13 @@ public class DiaryController {
     @GetMapping("/calendar/monthly")
     public ResponseEntity<SuccessResponse<List<GetMonthlyDiariesResponse>>> getMonthlyDiaries(
         @Parameter(description = "조회할 연도", in = ParameterIn.QUERY) @RequestParam("year") int year,
-        @Parameter(description = "조회할 달", in = ParameterIn.QUERY) @RequestParam("month") int month
-        , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+        @Parameter(description = "조회할 달", in = ParameterIn.QUERY) @RequestParam("month") int month,
+        @Parameter(description = "유저 타임존", in = ParameterIn.QUERY)
+        @RequestParam(name = "timezone", required = false, defaultValue = "+09:00") ZoneId timezone,
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            diaryService.getMonthlyDiaries(tokenInfo.getUserId(), year, month)
+            diaryService.getMonthlyDiaries(tokenInfo.getUserId(), year, month, timezone)
         ).asHttp(HttpStatus.OK);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -94,7 +94,7 @@ public class DiaryController {
         @Parameter(description = "조회할 연도", in = ParameterIn.QUERY) @RequestParam("year") int year,
         @Parameter(description = "조회할 달", in = ParameterIn.QUERY) @RequestParam("month") int month,
         @Parameter(description = "유저 타임존", in = ParameterIn.QUERY)
-        @RequestParam(name = "timezone", required = false, defaultValue = "+09:00") ZoneId timezone,
+        @RequestParam(name = "timezone", required = false, defaultValue = "Asia/Seoul") ZoneId timezone,
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -89,11 +89,12 @@ public class DiaryController {
             description = "U001: 해당 토큰의 유저를 찾을 수 없습니다.",
             content = @Content(schema = @Schema(hidden = true))),
     })
+    @Parameter(name = "timezone", description = "유저 타임존", in = ParameterIn.QUERY,
+        schema = @Schema(type = "string", defaultValue = "Asia/Seoul"))
     @GetMapping("/calendar/monthly")
     public ResponseEntity<SuccessResponse<List<GetMonthlyDiariesResponse>>> getMonthlyDiaries(
         @Parameter(description = "조회할 연도", in = ParameterIn.QUERY) @RequestParam("year") int year,
         @Parameter(description = "조회할 달", in = ParameterIn.QUERY) @RequestParam("month") int month,
-        @Parameter(description = "유저 타임존", in = ParameterIn.QUERY)
         @RequestParam(name = "timezone", required = false, defaultValue = "Asia/Seoul") ZoneId timezone,
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -3,6 +3,8 @@ package tipitapi.drawmytoday.diary.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -117,5 +119,9 @@ public class Diary extends BaseEntityWithUpdate {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public ZonedDateTime getDiaryDateWithZone() {
+        return this.diaryDate.atZone(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetMonthlyDiariesResponse.java
@@ -1,13 +1,11 @@
 package tipitapi.drawmytoday.diary.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,14 +20,13 @@ public class GetMonthlyDiariesResponse {
     @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
     private final String imageUrl;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+    @JsonSerialize(using = ZonedDateTimeSerializer.class)
     @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
-    private final LocalDateTime date;
+    private final ZonedDateTime date;
 
     public static GetMonthlyDiariesResponse of(Long diaryId, String imageUrl,
-        LocalDateTime diaryDate) {
+        ZonedDateTime diaryDate) {
         return new GetMonthlyDiariesResponse(diaryId, imageUrl, diaryDate);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -1,6 +1,7 @@
 package tipitapi.drawmytoday.diary.service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -58,10 +59,11 @@ public class DiaryService {
         return GetDiaryResponse.of(diary, imageUrl, emotionText, promptText);
     }
 
-    public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, int year, int month) {
+    public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, int year, int month,
+        ZoneId timezone) {
         User user = validateUserService.validateUserById(userId);
-        LocalDateTime startMonth = DateUtils.getStartDate(year, month);
-        LocalDateTime endMonth = DateUtils.getEndDate(year, month);
+        LocalDateTime startMonth = DateUtils.getStartDate(timezone, year, month);
+        LocalDateTime endMonth = DateUtils.getEndDate(timezone, year, month);
         List<Diary> getDiaryList = diaryRepository.findAllByUserUserIdAndDiaryDateBetween(
             user.getUserId(), startMonth, endMonth);
         return convertDiariesToResponse(getDiaryList);

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -138,7 +138,7 @@ public class DiaryService {
                 String imageUrl = s3PreSignedService.getPreSignedUrlForShare(
                     diary.getImageList().get(0).getImageUrl(), 30);
                 return GetMonthlyDiariesResponse.of(diary.getDiaryId(), imageUrl,
-                    diary.getDiaryDate());
+                    diary.getDiaryDateWithZone());
             })
             .collect(Collectors.toList());
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -1,6 +1,7 @@
 package tipitapi.drawmytoday.diary.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -123,7 +124,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 monthlyDiaries.add(new GetMonthlyDiariesResponse(diaryId, "imageUrl",
                     LocalDateTime.of(year, month, 1, 1, 1, 1)));
             }
-            given(diaryService.getMonthlyDiaries(REQUEST_USER_ID, 2023, 7, defaultTimezone))
+            given(diaryService.getMonthlyDiaries(
+                eq(REQUEST_USER_ID), eq(2023), eq(7), any(ZoneId.class)))
                 .willReturn(monthlyDiaries);
 
             // when

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -122,7 +122,7 @@ class DiaryControllerTest extends ControllerTestSetup {
             List<GetMonthlyDiariesResponse> monthlyDiaries = new ArrayList<>();
             for (long diaryId = 1; diaryId < 4; diaryId++) {
                 monthlyDiaries.add(new GetMonthlyDiariesResponse(diaryId, "imageUrl",
-                    LocalDateTime.of(year, month, 1, 1, 1, 1)));
+                    LocalDateTime.of(year, month, 1, 1, 1).atZone(defaultTimezone)));
             }
             given(diaryService.getMonthlyDiaries(
                 eq(REQUEST_USER_ID), eq(2023), eq(7), any(ZoneId.class)))
@@ -139,8 +139,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 .andExpect(jsonPath("$.data[0].id").value(monthlyDiaries.get(0).getId()))
                 .andExpect(
                     jsonPath("$.data[0].imageUrl").value(monthlyDiaries.get(0).getImageUrl()))
-                .andExpect(
-                    jsonPath("$.data[0].date").value(monthlyDiaries.get(0).getDate().toString()));
+                .andExpect(jsonPath("$.data[0].date").exists());
         }
 
         @Test

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -14,6 +14,7 @@ import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -192,6 +193,8 @@ class DiaryServiceTest {
     @DisplayName("getMonthlyDiaries 메소드 테스트")
     class GetMonthlyDiariesTest {
 
+        private final ZoneId timezone = ZoneId.of("Asia/Seoul");
+
         @Nested
         @DisplayName("userId에 해당하는 유저가 존재하지 않을 경우")
         class if_user_not_exists {
@@ -202,7 +205,7 @@ class DiaryServiceTest {
                 given(validateUserService.validateUserById(1L)).willThrow(
                     new UserNotFoundException());
 
-                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6, timezone))
                     .isInstanceOf(UserNotFoundException.class);
             }
         }
@@ -218,7 +221,7 @@ class DiaryServiceTest {
                 User user = createUser();
                 given(validateUserService.validateUserById(1L)).willReturn(user);
 
-                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value, timezone))
                     .isInstanceOf(BusinessException.class);
             }
 
@@ -229,7 +232,7 @@ class DiaryServiceTest {
                 User user = createUser();
                 given(validateUserService.validateUserById(1L)).willReturn(user);
 
-                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, value, timezone))
                     .isInstanceOf(BusinessException.class);
             }
         }
@@ -248,7 +251,7 @@ class DiaryServiceTest {
                     any(Long.class), any(LocalDateTime.class), any(LocalDateTime.class)))
                     .willReturn(List.of(diary));
 
-                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6))
+                assertThatThrownBy(() -> diaryService.getMonthlyDiaries(1L, 2023, 6, timezone))
                     .isInstanceOf(ImageNotFoundException.class);
             }
 
@@ -265,7 +268,7 @@ class DiaryServiceTest {
 
                 List<GetMonthlyDiariesResponse> getDiaryResponses = diaryService.getMonthlyDiaries(
                     1L,
-                    2023, 6);
+                    2023, 6, timezone);
 
                 assertThat(getDiaryResponses).hasSize(1);
                 assertThat(getDiaryResponses.get(0).getId()).isEqualTo(diary.getDiaryId());


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- request parameter에 timezone을 같이 받도록 수정
  - default 값으로 Asia/Seoul 
  - UTC, Asia/Seoul, +09:00 등 다양한 타입 지원(프론트에서 보내는 포멧과 맞는지 확인 필요)
- StringToZoneIdConverter 추가
  - WebConfig에 등록
- timezone 값에 따라 db에 조회할 구간 수정
- response의 diaryDate 값에 타임존 정보 추가
- 실패하는 테스트 수정

## 관련 이슈

close #167 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
