### PR TITLE
일기 생성시 프론트로부터 타임존 정보를 받아 일기 limit 검증 + 유저 로컬 시각으로 일기 생성 시각 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 tasks.named('test') {
-//    useJUnitPlatform()
+    useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+//    useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import tipitapi.drawmytoday.common.converter.StringToLanguageConverter;
+import tipitapi.drawmytoday.common.converter.StringToZoneIdConverter;
 import tipitapi.drawmytoday.common.resolver.AuthUserArgumentResolver;
 
 @Configuration
@@ -15,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthUserArgumentResolver authUserArgumentResolver;
     private final StringToLanguageConverter stringToLanguageConverter;
+    private final StringToZoneIdConverter stringToZoneOffsetConverter;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -24,5 +26,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(stringToLanguageConverter);
+        registry.addConverter(stringToZoneOffsetConverter);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/converter/StringToZoneIdConverter.java
+++ b/src/main/java/tipitapi/drawmytoday/common/converter/StringToZoneIdConverter.java
@@ -1,0 +1,19 @@
+package tipitapi.drawmytoday.common.converter;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToZoneIdConverter implements Converter<String, ZoneId> {
+
+    @Override
+    public ZoneId convert(String source) {
+        try {
+            return ZoneId.of(source);
+        } catch (DateTimeException e) {
+            return ZoneId.of("Asia/Seoul");
+        }
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.time.ZoneId;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -159,24 +160,27 @@ public class DiaryController {
             description = "IIS001 : 이미지 스트림을 가져오는데 실패하였습니다.",
             content = @Content(schema = @Schema(hidden = true))),
     })
+    @Parameter(name = "timezone", description = "유저 타임존", in = ParameterIn.QUERY,
+        schema = @Schema(type = "string", defaultValue = "Asia/Seoul"))
     @PostMapping()
     public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createDiary(
         @RequestBody @Valid CreateDiaryRequest createDiaryRequest,
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
         @Parameter(description = "테스트 여부", in = ParameterIn.QUERY)
-        @RequestParam(value = "test", required = false, defaultValue = "false") boolean test
+        @RequestParam(value = "test", required = false, defaultValue = "false") boolean test,
+        @RequestParam(value = "timezone", required = false, defaultValue = "Asia/Seoul") ZoneId timezone
     ) throws DallERequestFailException, ImageInputStreamFailException {
         CreateDiaryResponse response;
         if (test) {
             response = createDiaryService.createTestDiary(tokenInfo.getUserId(),
                 createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate());
+                createDiaryRequest.getDiaryDate(), timezone);
         } else {
             response = createDiaryService.createDiary(tokenInfo.getUserId(),
                 createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate());
+                createDiaryRequest.getDiaryDate(), timezone);
         }
         return SuccessResponse.of(response).asHttp(HttpStatus.CREATED);
     }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.diary.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -93,22 +94,24 @@ public class Diary extends BaseEntityWithUpdate {
         this.imageList = new ArrayList<>();
     }
 
-    public static Diary of(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+    public static Diary of(User user, Emotion emotion, LocalDate diaryDate, ZoneId timezone,
+        String notes) {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(diaryDate.atTime(LocalTime.now()))
+            .diaryDate(diaryDate.atTime(LocalTime.now(timezone)))
             .notes(notes)
             .isAi(true)
             .isTest(false)
             .build();
     }
 
-    public static Diary ofTest(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+    public static Diary ofTest(User user, Emotion emotion, LocalDate diaryDate, ZoneId timezone,
+        String notes) {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(diaryDate.atTime(LocalTime.now()))
+            .diaryDate(diaryDate.atTime(LocalTime.now(timezone)))
             .notes(notes)
             .isAi(true)
             .isTest(true)

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -1,7 +1,6 @@
 package tipitapi.drawmytoday.diary.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,7 +46,7 @@ public class CreateDiaryService {
         try {
             byte[] dallEImage = dallEService.getImageAsUrl(prompt);
 
-            Diary diary = saveDiary(notes, user, emotion, diaryDate, false);
+            Diary diary = saveDiary(notes, user, emotion, diaryDate, timezone, false);
             promptService.createPrompt(diary, prompt, true);
             imageService.uploadAndCreateImage(diary, dallEImage, true);
 
@@ -64,7 +63,7 @@ public class CreateDiaryService {
         User user = validateUserService.validateUserWithDrawLimit(userId, timezone);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
 
-        Diary diary = saveDiary(notes, user, emotion, diaryDate, true);
+        Diary diary = saveDiary(notes, user, emotion, diaryDate, timezone, true);
         String prompt = promptTextService.createPromptText(emotion, keyword);
         promptService.createPrompt(diary, prompt, true);
         imageService.createImage(diary, DUMMY_IMAGE_PATH, true);
@@ -73,14 +72,16 @@ public class CreateDiaryService {
     }
 
     private Diary saveDiary(String notes, User user, Emotion emotion, LocalDate diaryDate,
-        boolean testDiary) {
+        ZoneId timezone, boolean testDiary) {
         String encryptedNotes = encryptor.encrypt(notes);
-        user.setLastDiaryDate(LocalDateTime.now());
+        user.updateLastDiaryDate(timezone);
 
         if (testDiary) {
-            return diaryRepository.save(Diary.ofTest(user, emotion, diaryDate, encryptedNotes));
+            return diaryRepository.save(
+                Diary.ofTest(user, emotion, diaryDate, timezone, encryptedNotes));
         } else {
-            return diaryRepository.save(Diary.of(user, emotion, diaryDate, encryptedNotes));
+            return diaryRepository.save(
+                Diary.of(user, emotion, diaryDate, timezone, encryptedNotes));
         }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.diary.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,10 +37,10 @@ public class CreateDiaryService {
         noRollbackFor = {DallERequestFailException.class, DallERequestFailException.class,
             ImageInputStreamFailException.class})
     public CreateDiaryResponse createDiary(Long userId, Long emotionId, String keyword,
-        String notes, LocalDate diaryDate)
+        String notes, LocalDate diaryDate, ZoneId timezone)
         throws DallERequestFailException, ImageInputStreamFailException {
         // TODO: 이미지 여러 개로 요청할 경우의 핸들링 필요
-        User user = validateUserService.validateUserWithDrawLimit(userId);
+        User user = validateUserService.validateUserWithDrawLimit(userId, timezone);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
         String prompt = promptTextService.createPromptText(emotion, keyword);
 
@@ -59,8 +60,8 @@ public class CreateDiaryService {
 
     @Transactional(readOnly = false)
     public CreateDiaryResponse createTestDiary(Long userId, Long emotionId, String keyword,
-        String notes, LocalDate diaryDate) {
-        User user = validateUserService.validateUserWithDrawLimit(userId);
+        String notes, LocalDate diaryDate, ZoneId timezone) {
+        User user = validateUserService.validateUserWithDrawLimit(userId, timezone);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
 
         Diary diary = saveDiary(notes, user, emotion, diaryDate, true);

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -1,7 +1,9 @@
 package tipitapi.drawmytoday.user.domain;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -75,6 +77,12 @@ public class User extends BaseEntityWithUpdate {
     public boolean checkDrawLimit() {
         return this.getLastDiaryDate() == null
             || !this.getLastDiaryDate().toLocalDate().equals(LocalDate.now());
+    }
+
+    public boolean checkDrawLimit(ZoneId timezone) {
+        LocalDate today = LocalDate.ofInstant(Instant.now(), timezone);
+        return this.getLastDiaryDate() == null
+            || !this.getLastDiaryDate().toLocalDate().equals(today);
     }
 
     public boolean isAdmin() {

--- a/src/main/java/tipitapi/drawmytoday/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/user/domain/User.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.user.domain;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -80,12 +79,16 @@ public class User extends BaseEntityWithUpdate {
     }
 
     public boolean checkDrawLimit(ZoneId timezone) {
-        LocalDate today = LocalDate.ofInstant(Instant.now(), timezone);
+        LocalDate userBasedToday = LocalDate.now(timezone);
         return this.getLastDiaryDate() == null
-            || !this.getLastDiaryDate().toLocalDate().equals(today);
+            || !this.getLastDiaryDate().toLocalDate().equals(userBasedToday);
     }
 
     public boolean isAdmin() {
         return this.userRole == UserRole.ADMIN;
+    }
+
+    public void updateLastDiaryDate(ZoneId timezone) {
+        this.lastDiaryDate = LocalDateTime.now(timezone);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
+++ b/src/main/java/tipitapi/drawmytoday/user/service/ValidateUserService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.user.service;
 
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,9 +33,9 @@ public class ValidateUserService {
             .orElse(null);
     }
 
-    public User validateUserWithDrawLimit(Long userId) {
+    public User validateUserWithDrawLimit(Long userId, ZoneId timezone) {
         User user = validateUserById(userId);
-        if (user.checkDrawLimit()) {
+        if (user.checkDrawLimit(timezone)) {
             return user;
         } else {
             if (useAdRewardService.useReward(userId)) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.common.testdata;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
@@ -10,11 +11,11 @@ import tipitapi.drawmytoday.user.domain.User;
 public class TestDiary {
 
     public static Diary createDiary(User user, Emotion emotion) {
-        return Diary.of(user, emotion, LocalDate.now(), null);
+        return Diary.of(user, emotion, LocalDate.now(), ZoneOffset.UTC, null);
     }
 
     public static Diary createTestDiary(User user, Emotion emotion) {
-        return Diary.ofTest(user, emotion, LocalDate.now(), null);
+        return Diary.ofTest(user, emotion, LocalDate.now(), ZoneOffset.UTC, null);
     }
 
     public static Diary createDiaryWithId(Long diaryId, User user, Emotion emotion) {

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -2,7 +2,7 @@ package tipitapi.drawmytoday.common.testdata;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
@@ -11,11 +11,11 @@ import tipitapi.drawmytoday.user.domain.User;
 public class TestDiary {
 
     public static Diary createDiary(User user, Emotion emotion) {
-        return Diary.of(user, emotion, LocalDate.now(), ZoneOffset.UTC, null);
+        return Diary.of(user, emotion, LocalDate.now(), ZoneId.of("Asia/Seoul"), null);
     }
 
     public static Diary createTestDiary(User user, Emotion emotion) {
-        return Diary.ofTest(user, emotion, LocalDate.now(), ZoneOffset.UTC, null);
+        return Diary.ofTest(user, emotion, LocalDate.now(), ZoneId.of("Asia/Seoul"), null);
     }
 
     public static Diary createDiaryWithId(Long diaryId, User user, Emotion emotion) {

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -17,8 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -208,7 +206,7 @@ class DiaryControllerTest extends ControllerTestSetup {
         @DisplayName("유저가 마지막으로 일기를 생성한 시각을 반환한다.")
         void return_last_creation() throws Exception {
             // given
-            ZonedDateTime lastCreation = LocalDateTime.now().atZone(ZoneOffset.UTC);
+            LocalDateTime lastCreation = LocalDateTime.now();
             given(diaryService.getLastCreation(REQUEST_USER_ID)).willReturn(
                 new GetLastCreationResponse(lastCreation));
 
@@ -217,7 +215,7 @@ class DiaryControllerTest extends ControllerTestSetup {
 
             // then
             result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.lastCreation").exists());
+                .andExpect(jsonPath("$.data.lastCreation").value(parseLocalDateTime(lastCreation)));
         }
     }
 

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -1,7 +1,9 @@
 package tipitapi.drawmytoday.diary.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -14,6 +16,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -203,7 +208,7 @@ class DiaryControllerTest extends ControllerTestSetup {
         @DisplayName("유저가 마지막으로 일기를 생성한 시각을 반환한다.")
         void return_last_creation() throws Exception {
             // given
-            LocalDateTime lastCreation = LocalDateTime.now();
+            ZonedDateTime lastCreation = LocalDateTime.now().atZone(ZoneOffset.UTC);
             given(diaryService.getLastCreation(REQUEST_USER_ID)).willReturn(
                 new GetLastCreationResponse(lastCreation));
 
@@ -212,7 +217,7 @@ class DiaryControllerTest extends ControllerTestSetup {
 
             // then
             result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.lastCreation").value(parseLocalDateTime(lastCreation)));
+                .andExpect(jsonPath("$.data.lastCreation").exists());
         }
     }
 
@@ -224,6 +229,8 @@ class DiaryControllerTest extends ControllerTestSetup {
         private final String notes = "notes";
         private final LocalDate diaryDate = LocalDate.now();
         private final Long emotionId = 1L;
+
+        private final ZoneId timezone = ZoneId.of("Asia/Seoul");
 
         @Nested
         @DisplayName("content 값 중")
@@ -247,7 +254,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(ZoneId.class));
             }
 
             @Test
@@ -270,7 +278,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(ZoneId.class));
             }
 
             @Test
@@ -291,7 +300,41 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(ZoneId.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("timezone 쿼리 파라미터가")
+        class Timezone_query_param_is {
+
+            @Test
+            @DisplayName("없다면 기본값으로 KST를 사용한다.")
+            void not_exist_then_use_KST() throws Exception {
+                // given
+                Long diaryId = 1L;
+                given(createDiaryService.createDiary(
+                    any(), any(), any(), any(), any(), any(ZoneId.class)))
+                    .willReturn(new CreateDiaryResponse(diaryId));
+
+                // when
+                Map<String, Object> requestMap = new HashMap<>();
+                requestMap.put("emotionId", emotionId);
+                requestMap.put("keyword", keyword);
+                requestMap.put("notes", notes);
+                requestMap.put("diaryDate", diaryDate);
+                String requestBody = objectMapper.writeValueAsString(requestMap);
+
+                ResultActions result = mockMvc.perform(post(BASIC_URL)
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+                // then
+                result.andExpect(status().isCreated());
+                then(createDiaryService).should().createDiary(
+                    any(), any(), any(), any(), any(), eq(ZoneId.of("Asia/Seoul")));
             }
         }
 
@@ -305,7 +348,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // given
                 Long diaryId = 1L;
                 given(createDiaryService.createDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, timezone))
                     .willReturn(new CreateDiaryResponse(diaryId));
 
                 // when
@@ -331,7 +374,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // given
                 Long testDiaryId = 1L;
                 given(createDiaryService.createTestDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, timezone))
                     .willReturn(new CreateDiaryResponse(testDiaryId));
 
                 // when

--- a/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
@@ -67,7 +67,7 @@ class CreateDiaryServiceTest {
         private final String NOTES = "노트";
         private final LocalDate DIARY_DATE = LocalDate.now();
 
-        private final ZoneId TIMEZONE = ZoneId.of("UTC");
+        private final ZoneId TIMEZONE = ZoneId.of("Asia/Seoul");
 
         @Nested
         @DisplayName("dallE 요청 시")
@@ -156,7 +156,7 @@ class CreateDiaryServiceTest {
             String notes = "노트";
             String keyword = "키워드";
             LocalDateTime lastDateTime = diaryDate.minusDays(1L).atTime(1, 1);
-            ZoneId timezone = ZoneId.of("UTC");
+            ZoneId timezone = ZoneId.of("Asia/Seoul");
 
             User user = TestUser.createUserWithId(userId);
             user.setLastDiaryDate(lastDateTime);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 일기 limit 검증시 유저 로컬 시각과 db에 저장된 마지막으로 일기를 작성한 날짜를 비교하여 검증
- 일기 저장시 diaryDate에 유저가 작성하려는 일기 날짜와 유저 로컬 시각을 합쳐서 저장
- 테스트 코드 수정

__유저 로컬 시각을 프론트로부터 그대로 받을지, 아니면 타임존 정보만 받고 서버에서 유저 로컬 시각을 계산할지 고민을 많이 했는데 타임존 정보를 받는게 보안에 덜 취약하기도 하고 유저가 핸드폰 시각을 마음대로 바꾸어도 안전하기에 타임존을 받도록 구현했습니다!__

## 관련 이슈

close #173

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
