### PR TITLE
모니터링 툴 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.26')
     implementation 'software.amazon.awssdk:s3'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
 //	스프링 시큐리티, jwt 설정
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation platform('software.amazon.awssdk:bom:2.20.26')
     implementation 'software.amazon.awssdk:s3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 //	스프링 시큐리티, jwt 설정
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
         "/oauth2/apple/login",
         "/oauth2/refresh",
         "/oauth2/expiredJwt",
-        "/health/server"
+        "/health/server",
+        "/actuator/**"
     };
 
     @Bean

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -1,0 +1,10 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+  endpoint:
+    prometheus:
+      enabled: true
+  server:
+    port: 9292

--- a/src/main/resources/application-actuator.yml
+++ b/src/main/resources/application-actuator.yml
@@ -8,3 +8,8 @@ management:
       enabled: true
   server:
     port: 9292
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 spring:
-    profiles:
-        active: ${profile}
-        include: oauth, aws, openai
+  profiles:
+    active: ${profile}
+    include: oauth, aws, openai, actuator
 encryptor:
-    secret:
-        key: ${ENCRYPTOR_SECRET_KEY}
+  secret:
+    key: ${ENCRYPTOR_SECRET_KEY}
 presigned-image:
-    expiration:
-        admin-diaries: ${PRESIGNED_IMAGE_EXPIRATION_ADMIN_DIARIES}
+  expiration:
+    admin-diaries: ${PRESIGNED_IMAGE_EXPIRATION_ADMIN_DIARIES}


### PR DESCRIPTION
# 구현 내용
### [그라파나 대시보드](http://54.180.203.21:3000/dashboards)

### [노션 참고 자료](https://knowing-jester-927.notion.site/1c3890108dad488f81980820c25d6a2a?pvs=4)

### 전체 구조도
<img width="548" alt="image" src="https://github.com/tipi-tapi/ai-paint-today-BE/assets/39454230/cea3ec03-814e-49ca-bc00-86f7c0c138a3">


## 구현 요약

- 프로메테우스, 그라파나 띄운 ec2 서버 추가
- 테스트 서버 인바운드 규칙에 actuator 포트 추가
- 테스트 서버에 node exporter 추가

## 실서버 배포 이후 작업해야 할 것

- 실서버에 node exporter 추가
- 실서버 ec2 인바운드 규칙에 9292 포트 열기(+ 모니터링 서버 ip만 접근 가능하도록 설정)
- 모니터링 서버의 prometheus.yaml 설정 변경(실서버 메트릭 수집)
- 그라파나 실서버 alert 추가

## 관련 이슈

close #143

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
