### PR TITLE
일기 생성시, 주어진 날짜로 생성된 일기가 있는지 검증

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     DIARY_NOT_FOUND(404, "D001", "일기를 찾을 수 없습니다."),
     DIARY_NOT_OWNER(403, "D002", "자신의 일기에만 접근할 수 있습니다."),
     INVALID_CREATE_DIARY_DATE(400, "D003", "일기를 그릴 수 없는 날짜입니다."),
+    DIARY_DATE_ALREADY_EXISTS(409, "D004", "이미 일기를 그린 날짜입니다."),
 
     // Image
     IMAGE_NOT_FOUND(404, "I001", "선택된 이미지를 찾을 수 없습니다."),

--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.common.utils;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
@@ -22,9 +21,9 @@ public class DateUtils {
         return LocalDateTime.of(year, month, getMaxDay(month), 23, 59);
     }
 
-    public static Date getDate(int year, int month, int day) {
+    public static LocalDate getDate(int year, int month, int day) {
         validateDate(month, day);
-        return Date.valueOf(LocalDate.of(year, month, day));
+        return LocalDate.of(year, month, day);
     }
 
     private static void validateMonth(int month) {

--- a/src/main/java/tipitapi/drawmytoday/diary/exception/DiaryDateAlreadyExistsException.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/exception/DiaryDateAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.diary.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class DiaryDateAlreadyExistsException extends BusinessException {
+
+    public DiaryDateAlreadyExistsException() {
+        super(ErrorCode.DIARY_DATE_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryQueryRepository.java
@@ -1,12 +1,17 @@
 package tipitapi.drawmytoday.diary.repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.diary.domain.Diary;
 
 public interface DiaryQueryRepository {
 
     Page<GetDiaryAdminResponse> getDiariesForMonitorAsPage(Pageable pageable,
         Direction direction, Long emotionId);
+
+    Optional<Diary> getDiaryExistsByDiaryDate(Long userId, LocalDate diaryDate);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryQueryRepositoryImpl.java
@@ -8,7 +8,9 @@ import static tipitapi.drawmytoday.emotion.domain.QEmotion.emotion;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +18,7 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.support.PageableExecutionUtils;
 import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.admin.dto.QGetDiaryAdminResponse;
+import tipitapi.drawmytoday.diary.domain.Diary;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 
 @RequiredArgsConstructor
@@ -56,4 +59,12 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Optional<Diary> getDiaryExistsByDiaryDate(Long userId, LocalDate diaryDate) {
+
+        return Optional.ofNullable(queryFactory.selectFrom(diary)
+            .where(diary.diaryDate.between(diaryDate.atStartOfDay(), diaryDate.atTime(23, 59, 59))
+                .and(diary.user.userId.eq(userId)))
+            .fetchFirst());
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/repository/DiaryRepository.java
@@ -1,12 +1,10 @@
 package tipitapi.drawmytoday.diary.repository;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import tipitapi.drawmytoday.diary.domain.Diary;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryQueryRepository {
@@ -16,7 +14,4 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryQueryR
         LocalDateTime endMonth);
 
     Optional<Diary> findFirstByUserUserIdOrderByCreatedAtDesc(Long userId);
-
-    @Query("select d from Diary d where d.user.userId = ?1 and DATE(d.diaryDate) = ?2 order by d.createdAt desc")
-    List<Diary> findByUserIdAndDiaryDate(Long userId, Date diaryDate);
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/CreateDiaryService.java
@@ -26,6 +26,7 @@ public class CreateDiaryService {
     private final ImageService imageService;
     private final ValidateUserService validateUserService;
     private final ValidateEmotionService validateEmotionService;
+    private final ValidateDiaryService validateDiaryService;
     private final DallEService dallEService;
     private final PromptService promptService;
     private final PromptTextService promptTextService;
@@ -40,6 +41,7 @@ public class CreateDiaryService {
         throws DallERequestFailException, ImageInputStreamFailException {
         // TODO: 이미지 여러 개로 요청할 경우의 핸들링 필요
         User user = validateUserService.validateUserWithDrawLimit(userId);
+        validateDiaryService.validateExistsByDate(userId, diaryDate);
         Emotion emotion = validateEmotionService.validateEmotionById(emotionId);
         String prompt = promptTextService.createPromptText(emotion, keyword);
 

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.diary.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -70,13 +70,14 @@ public class DiaryService {
     public GetDiaryExistByDateResponse getDiaryExistByDate(Long userId, int year, int month,
         int day) {
         User user = validateUserService.validateUserById(userId);
-        Date date = DateUtils.getDate(year, month, day);
-        List<Diary> diaries = diaryRepository.findByUserIdAndDiaryDate(
-            user.getUserId(), date);
-        if (diaries.isEmpty()) {
+        LocalDate date = DateUtils.getDate(year, month, day);
+
+        Optional<Diary> diary = diaryRepository.getDiaryExistsByDiaryDate(user.getUserId(), date);
+        
+        if (diary.isEmpty()) {
             return GetDiaryExistByDateResponse.ofNotExist();
         } else {
-            return GetDiaryExistByDateResponse.ofExist(diaries.get(0).getDiaryId());
+            return GetDiaryExistByDateResponse.ofExist(diary.get().getDiaryId());
         }
     }
 

--- a/src/main/java/tipitapi/drawmytoday/diary/service/ValidateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/ValidateDiaryService.java
@@ -1,9 +1,11 @@
 package tipitapi.drawmytoday.diary.service;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.exception.DiaryDateAlreadyExistsException;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
@@ -21,6 +23,11 @@ public class ValidateDiaryService {
             .orElseThrow(DiaryNotFoundException::new);
         ownedByUser(diary, user);
         return diary;
+    }
+
+    public void validateExistsByDate(Long userId, LocalDate diaryDate) {
+        diaryRepository.getDiaryExistsByDiaryDate(userId, diaryDate)
+            .orElseThrow(DiaryDateAlreadyExistsException::new);
     }
 
     private void ownedByUser(Diary diary, User user) {

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -5,7 +5,7 @@ import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithCrea
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithDate;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
-import java.sql.Date;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -317,69 +317,49 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
     }
 
     @Nested
-    @DisplayName("findByUserIdAndDiaryDate")
-    class FindByUserIdAndDiaryDateTest {
+    @DisplayName("getDiaryExistsByDiaryDate 메서드 테스트")
+    class GetDiaryExistsByDiaryDateTest {
 
-        private final LocalDateTime DIARY_DATE_TIME = LocalDateTime.of(2021, 1, 1, 0, 0);
-        private final Date DIARY_DATE = Date.valueOf(DIARY_DATE_TIME.toLocalDate());
+        private final LocalDate DIARY_DATE = LocalDate.of(2021, 1, 1);
 
         @Nested
         @DisplayName("해당 날짜에 일기가 없을 경우")
         class if_diary_not_exist_at_date {
 
             @Test
-            @DisplayName("빈 리스트를 반환한다.")
-            void return_empty_list() {
-                assertThat(
-                    diaryRepository.findByUserIdAndDiaryDate(createUser().getUserId(), DIARY_DATE))
-                    .isEmpty();
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                assertThat(diaryRepository.getDiaryExistsByDiaryDate(createUser().getUserId(),
+                    DIARY_DATE)).isEmpty();
             }
         }
 
         @Nested
-        @DisplayName("해당 날짜에 일기가 있을 경우")
-        class if_diary_exist_at_date {
+        @DisplayName("존재하지 않는 유저 ID인 경우")
+        class if_user_id_not_exist {
 
-            @Nested
-            @DisplayName("여러개의 일기가 있을 경우")
-            class if_diary_exist_more_than_one {
-
-                @Test
-                @DisplayName("최신순으로 해당 날짜의 일기 리스트를 반환한다.")
-                void return_diaries_order_by_newest() {
-                    User user = createUser();
-                    Emotion emotion = createEmotion();
-                    Diary prevDiary = diaryRepository.save(
-                        createDiaryWithDate(DIARY_DATE_TIME, user, emotion));
-                    Diary lastDiary = diaryRepository.save(
-                        createDiaryWithDate(DIARY_DATE_TIME, user, emotion));
-
-                    List<Diary> diaries = diaryRepository.findByUserIdAndDiaryDate(user.getUserId(),
-                        DIARY_DATE);
-
-                    assertThat(diaries.size()).isEqualTo(2);
-                    assertThat(diaries.get(0).getDiaryId()).isEqualTo(lastDiary.getDiaryId());
-                    assertThat(diaries.get(1).getDiaryId()).isEqualTo(prevDiary.getDiaryId());
-                }
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                assertThat(diaryRepository.getDiaryExistsByDiaryDate(1L, DIARY_DATE)).isEmpty();
             }
+        }
 
-            @Nested
-            @DisplayName("한개의 일기만 있을 경우")
-            class if_diary_exist_only_one {
+        @Nested
+        @DisplayName("해당 날짜에 주어진 유저의 일기가 있을 경우")
+        class if_diary_exists {
 
-                @Test
-                @DisplayName("해당 날짜의 일기를 반환한다.")
-                void return_diary() {
-                    User user = createUser();
-                    LocalDateTime diaryDate = LocalDateTime.of(2021, 1, 1, 0, 0);
-                    Diary diary = diaryRepository.save(
-                        createDiaryWithDate(diaryDate, user, createEmotion()));
+            @Test
+            @DisplayName("일기를 반환한다.")
+            void return_diary() {
+                User user = createUser();
+                Diary diary = diaryRepository.save(createDiaryWithDate(DIARY_DATE.atTime(9, 0),
+                    user, createEmotion()));
 
-                    List<Diary> diaryList = diaryRepository.findByUserIdAndDiaryDate(
-                        user.getUserId(), DIARY_DATE);
-                    assertThat(diaryList.size()).isEqualTo(1);
-                    assertThat(diaryList.get(0).getDiaryId()).isEqualTo(diary.getDiaryId());
-                }
+                assertThat(diaryRepository.getDiaryExistsByDiaryDate(user.getUserId(), DIARY_DATE))
+                    .isPresent()
+                    .get()
+                    .isEqualTo(diary);
             }
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -13,9 +13,8 @@ import static tipitapi.drawmytoday.common.testdata.TestImage.createImage;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -365,8 +364,8 @@ class DiaryServiceTest {
             void it_returns_false() {
                 User user = createUserWithId(1L);
                 given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(diaryRepository.findByUserIdAndDiaryDate(anyLong(), any(Date.class)))
-                    .willReturn(new ArrayList<>());
+                given(diaryRepository.getDiaryExistsByDiaryDate(anyLong(), any(LocalDate.class)))
+                    .willReturn(Optional.empty());
 
                 GetDiaryExistByDateResponse response = diaryService.getDiaryExistByDate(
                     1L, 2023, 6, 1);
@@ -385,8 +384,8 @@ class DiaryServiceTest {
                 User user = createUserWithId(1L);
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 Diary diary = createDiaryWithId(1L, user, createEmotion());
-                given(diaryRepository.findByUserIdAndDiaryDate(anyLong(), any(Date.class)))
-                    .willReturn(List.of(diary));
+                given(diaryRepository.getDiaryExistsByDiaryDate(anyLong(), any(LocalDate.class)))
+                    .willReturn(Optional.of(diary));
 
                 GetDiaryExistByDateResponse response = diaryService.getDiaryExistByDate(
                     1L, 2023, 6, 1);

--- a/src/test/java/tipitapi/drawmytoday/diary/service/ValidateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/ValidateDiaryServiceTest.java
@@ -3,12 +3,14 @@ package tipitapi.drawmytoday.diary.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.common.testdata.TestDiary;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.diary.domain.Diary;
+import tipitapi.drawmytoday.diary.exception.DiaryDateAlreadyExistsException;
 import tipitapi.drawmytoday.diary.exception.DiaryNotFoundException;
 import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
@@ -102,6 +105,27 @@ class ValidateDiaryServiceTest {
                 Diary validatedDiary = validateDiaryService.validateDiaryById(1L, user);
 
                 assertThat(validatedDiary).isEqualTo(diary);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("validateExistsByDate 메소드 테스트")
+    class ValidateExistsByDateTest {
+
+        @Nested
+        @DisplayName("해당 날짜에 일기가 존재할 경우")
+        class if_diary_exists_on_date {
+
+            @Test
+            @DisplayName("DiaryDateAlreadyExistsException 예외를 발생시킨다.")
+            void it_throws_DiaryNotFoundException() {
+                given(diaryRepository.getDiaryExistsByDiaryDate(anyLong(), any(LocalDate.class)))
+                    .willReturn(Optional.empty());
+
+                assertThatThrownBy(
+                    () -> validateDiaryService.validateExistsByDate(1L, LocalDate.now()))
+                    .isInstanceOf(DiaryDateAlreadyExistsException.class);
             }
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[POST] /diary 일기 생성 API - 주어진 날짜로 생성된 일기가 있는지 검증
- DiaryDateAlreadyExistsException 예외 추가
- 주어진 날짜로 생성된 일기가 있다면 DiaryDateAlreadyExistsException 예외를 던짐
- queryDSL 기반의 getDiaryExistsByDiaryDate 레포지토리 메서드 추가. userId와 주어진 일자에 해당하는 일기 데이터를 반환함

[GET] /diary/calendar/date 특정 날짜 일기 존재 여부 조회 API - getDiaryExistsByDiaryDate 레포지토리 메서드를 사용하도록 변경
- 기존의 findByUserIdAndDiaryDate 레포지토리 메서드가 아닌 getDiaryExistsByDiaryDate 메서드를 사용하도록 변경
- findByUserIdAndDiaryDate 메서드 삭제, 관련 테스트 삭제

## 관련 이슈

close #177 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
