### PR TITLE
Ticket 엔티티 추가, 회원 가입시 티켓 7개 부여

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/AppleOAuthService.java
@@ -31,6 +31,7 @@ import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.oauth.exception.OAuthNotFoundException;
 import tipitapi.drawmytoday.oauth.properties.AppleProperties;
 import tipitapi.drawmytoday.oauth.repository.AuthRepository;
+import tipitapi.drawmytoday.ticket.service.TicketService;
 import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.service.UserService;
@@ -48,6 +49,7 @@ public class AppleOAuthService {
     private final UserService userService;
     private final AuthRepository authRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TicketService ticketService;
 
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin)
@@ -66,6 +68,7 @@ public class AppleOAuthService {
         } else {
             user = userService.registerUser(appleIdToken.getEmail(), SocialCode.APPLE);
             authRepository.save(new Auth(user, oAuthAccessToken.getRefreshToken()));
+            ticketService.createTicketByJoin(user);
         }
 
         String jwtAccessToken = jwtTokenProvider.createAccessToken(user.getUserId(),

--- a/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/oauth/service/GoogleOAuthService.java
@@ -29,6 +29,7 @@ import tipitapi.drawmytoday.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.oauth.exception.OAuthNotFoundException;
 import tipitapi.drawmytoday.oauth.properties.GoogleProperties;
 import tipitapi.drawmytoday.oauth.repository.AuthRepository;
+import tipitapi.drawmytoday.ticket.service.TicketService;
 import tipitapi.drawmytoday.user.domain.SocialCode;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.service.UserService;
@@ -46,6 +47,7 @@ public class GoogleOAuthService {
     private final ValidateUserService validateUserService;
     private final AuthRepository authRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TicketService ticketService;
 
 
     @Transactional
@@ -102,6 +104,7 @@ public class GoogleOAuthService {
     private User registerUser(OAuthUserProfile oAuthUserProfile, OAuthAccessToken accessToken) {
         User user = userService.registerUser(oAuthUserProfile.getEmail(), SocialCode.GOOGLE);
         authRepository.save(new Auth(user, accessToken.getRefreshToken()));
+        ticketService.createTicketByJoin(user);
         return user;
     }
 

--- a/src/main/java/tipitapi/drawmytoday/ticket/domain/Ticket.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/domain/Ticket.java
@@ -35,13 +35,13 @@ public class Ticket extends BaseEntity {
     @NotNull
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private TicketType type;
+    private TicketType ticketType;
 
     private LocalDateTime usedAt;
 
     private Ticket(User user, TicketType type) {
         this.user = user;
-        this.type = type;
+        this.ticketType = type;
     }
 
     public static Ticket of(User user, TicketType type) {

--- a/src/main/java/tipitapi/drawmytoday/ticket/domain/Ticket.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/domain/Ticket.java
@@ -1,0 +1,54 @@
+package tipitapi.drawmytoday.ticket.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.common.entity.BaseEntity;
+import tipitapi.drawmytoday.user.domain.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Ticket extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketId;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @NotNull
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TicketType type;
+
+    private LocalDateTime usedAt;
+
+    private Ticket(User user, TicketType type) {
+        this.user = user;
+        this.type = type;
+    }
+
+    public static Ticket of(User user, TicketType type) {
+        return new Ticket(user, type);
+    }
+
+    public void use() {
+        this.usedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/domain/TicketType.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/domain/TicketType.java
@@ -1,0 +1,16 @@
+package tipitapi.drawmytoday.ticket.domain;
+
+public enum TicketType {
+    JOIN("JOIN"),
+    AD_REWARD("AD_REWARD");
+
+    private final String key;
+
+    TicketType(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
@@ -3,6 +3,6 @@ package tipitapi.drawmytoday.ticket.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.ticket.domain.Ticket;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketQueryRepository {
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
 }

--- a/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
@@ -1,0 +1,8 @@
+package tipitapi.drawmytoday.ticket.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketQueryRepository {
+
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
@@ -1,5 +1,7 @@
 package tipitapi.drawmytoday.ticket.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,12 +19,10 @@ public class TicketService {
 
     @Transactional
     public void createTicketByJoin(User user) {
+        List<Ticket> tickets = new ArrayList<>();
         for (int i = 0; i < 7; i++) {
-            createTicket(user, TicketType.JOIN);
+            tickets.add(Ticket.of(user, TicketType.JOIN));
         }
-    }
-
-    private void createTicket(User user, TicketType type) {
-        ticketRepository.save(Ticket.of(user, type));
+        ticketRepository.saveAll(tickets);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
@@ -1,0 +1,27 @@
+package tipitapi.drawmytoday.ticket.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.domain.TicketType;
+import tipitapi.drawmytoday.ticket.repository.TicketRepository;
+import tipitapi.drawmytoday.user.domain.User;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+
+    public void createTicketByJoin(User user) {
+        for (int i = 0; i < 7; i++) {
+            createTicket(user, TicketType.JOIN);
+        }
+    }
+
+    private void createTicket(User user, TicketType type) {
+        ticketRepository.save(Ticket.of(user, type));
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
@@ -15,6 +15,7 @@ public class TicketService {
 
     private final TicketRepository ticketRepository;
 
+    @Transactional
     public void createTicketByJoin(User user) {
         for (int i = 0; i < 7; i++) {
             createTicket(user, TicketType.JOIN);

--- a/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
@@ -1,0 +1,41 @@
+package tipitapi.drawmytoday.ticket.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.repository.TicketRepository;
+import tipitapi.drawmytoday.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+public class TicketServiceTest {
+
+    @Mock
+    TicketRepository ticketRepository;
+    @InjectMocks
+    TicketService ticketService;
+
+    @Nested
+    @DisplayName("createTicketByJoin 메소드 테스트")
+    class CreateTicketByJoinTest {
+
+        @Test
+        @DisplayName("7개의 JOIN 타입의 티켓을 등록해야합니다.")
+        void it_creates_7_join_tickets() {
+            User user = createUser();
+
+            ticketService.createTicketByJoin(user);
+
+            verify(ticketRepository, times(7)).save(any(Ticket.class));
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
@@ -1,10 +1,12 @@
 package tipitapi.drawmytoday.ticket.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,9 +39,12 @@ public class TicketServiceTest {
 
             ticketService.createTicketByJoin(user);
 
-            ArgumentCaptor<Ticket> ticketArgumentCaptor = ArgumentCaptor.forClass(Ticket.class);
-            verify(ticketRepository, times(1)).save(ticketArgumentCaptor.capture());
-            assertEquals(ticketArgumentCaptor.getValue().getTicketType(), TicketType.JOIN);
+            ArgumentCaptor<List<Ticket>> ticketArgumentCaptor = ArgumentCaptor.forClass(List.class);
+            verify(ticketRepository, times(1)).saveAll(ticketArgumentCaptor.capture());
+
+            List<Ticket> tickets = ticketArgumentCaptor.getValue();
+            assertEquals(tickets.size(), 7);
+            assertThat(tickets).allMatch(ticket -> ticket.getTicketType() == TicketType.JOIN);
         }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/ticket/service/TicketServiceTest.java
@@ -1,6 +1,6 @@
 package tipitapi.drawmytoday.ticket.service;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.domain.TicketType;
 import tipitapi.drawmytoday.ticket.repository.TicketRepository;
 import tipitapi.drawmytoday.user.domain.User;
 
@@ -35,7 +37,9 @@ public class TicketServiceTest {
 
             ticketService.createTicketByJoin(user);
 
-            verify(ticketRepository, times(7)).save(any(Ticket.class));
+            ArgumentCaptor<Ticket> ticketArgumentCaptor = ArgumentCaptor.forClass(Ticket.class);
+            verify(ticketRepository, times(1)).save(ticketArgumentCaptor.capture());
+            assertEquals(ticketArgumentCaptor.getValue().getTicketType(), TicketType.JOIN);
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

Ticket 엔티티 추가
- ticketType 필드를 통해 가입시 부여된 티켓인지, 광고를 통해 부여된 티켓인지 구분할 수 있도록 구성하였습니다.
- 사용일자를 기록하기 위해, usedAt 필드를 추가하였습니다.

TicketType Enum 추가
- JOIN, AD_REWARD 값을 가지고 있습니다.
- JOIN 값은 회원가입시 부여된 티켓의 종류를 나타냅니다.
- AD_REWARD 값은 광고를 시청함으로써 등록된 티켓의 종류를 나타냅니다.

[POST] /oauth2/google/login, [POST] /oauth2/apple/login : 구글 로그인 / 애플 로그인 시 티켓 7개 등록
- TicketService의 createTicketByJoin 메서드를 통해 로그인시 티켓 7개를 등록하도록 만들었습니다.


아래 sql을 추가해야합니다.
```sql
CREATE TABLE ticket (
	ticket_id bigint NOT NULL AUTO_INCREMENT,
	created_at datetime NOT NULL,
	ticket_type varchar(255) NOT NULL,
	used_at datetime,
	user_id bigint NOT NULL,
	PRIMARY KEY (ticket_id)
);
ALTER TABLE ticket
	ADD FOREIGN KEY (user_id) REFERENCES user(user_id);
```

## 관련 이슈

close #180 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
