### PR TITLE
일기 생성시 Diary 엔티티의 diaryDate에 유저 현재 시각 받아서 저장

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -49,6 +50,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("handleIllegalArgument", e);
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
         return handleExceptionInternal(e, errorCode);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException e,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request) {
+        log.warn("handleHttpMessageNotReadable", e);
+        return handleExceptionInternal(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     // 이 외의 500 에러 처리

--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -171,12 +171,12 @@ public class DiaryController {
             response = createDiaryService.createTestDiary(tokenInfo.getUserId(),
                 createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate());
+                createDiaryRequest.getDiaryDate(), createDiaryRequest.getUserTime());
         } else {
             response = createDiaryService.createDiary(tokenInfo.getUserId(),
                 createDiaryRequest.getEmotionId(),
                 createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate());
+                createDiaryRequest.getDiaryDate(), createDiaryRequest.getUserTime());
         }
         return SuccessResponse.of(response).asHttp(HttpStatus.CREATED);
     }

--- a/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/domain/Diary.java
@@ -1,8 +1,6 @@
 package tipitapi.drawmytoday.diary.domain;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
@@ -93,22 +91,23 @@ public class Diary extends BaseEntityWithUpdate {
         this.imageList = new ArrayList<>();
     }
 
-    public static Diary of(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+    public static Diary of(User user, Emotion emotion, LocalDateTime diaryDateTime, String notes) {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(diaryDate.atTime(LocalTime.now()))
+            .diaryDate(diaryDateTime)
             .notes(notes)
             .isAi(true)
             .isTest(false)
             .build();
     }
 
-    public static Diary ofTest(User user, Emotion emotion, LocalDate diaryDate, String notes) {
+    public static Diary ofTest(User user, Emotion emotion, LocalDateTime diaryDateTime,
+        String notes) {
         return Diary.builder()
             .user(user)
             .emotion(emotion)
-            .diaryDate(diaryDate.atTime(LocalTime.now()))
+            .diaryDate(diaryDateTime)
             .notes(notes)
             .isAi(true)
             .isTest(true)

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/CreateDiaryRequest.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -22,7 +24,7 @@ public class CreateDiaryRequest {
     @NotNull
     @Schema(description = "감정 ID")
     private Long emotionId;
-    
+
     @Schema(description = "일기 키워드", nullable = true)
     private String keyword;
 
@@ -37,4 +39,16 @@ public class CreateDiaryRequest {
     @JsonDeserialize(using = LocalDateDeserializer.class)
     @Schema(description = "일기 날짜")
     private LocalDate diaryDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonDeserialize(using = LocalTimeDeserializer.class)
+    @Schema(description = "현재 유저 시간", nullable = true, example = "12:00:00")
+    private LocalTime userTime;
+
+    public LocalTime getUserTime() {
+        if (userTime == null) {
+            return LocalTime.now();
+        }
+        return userTime;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
@@ -28,6 +28,6 @@ public class TicketService {
 
     @Transactional
     public void createTicketByAdReward(User user) {
-        ticketRepository.save(Ticket.of(user, TicketType.AD_REWARD))
+        ticketRepository.save(Ticket.of(user, TicketType.AD_REWARD));
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.common.testdata;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.diary.domain.Diary;
@@ -10,11 +9,11 @@ import tipitapi.drawmytoday.user.domain.User;
 public class TestDiary {
 
     public static Diary createDiary(User user, Emotion emotion) {
-        return Diary.of(user, emotion, LocalDate.now(), null);
+        return Diary.of(user, emotion, LocalDateTime.now(), null);
     }
 
     public static Diary createTestDiary(User user, Emotion emotion) {
-        return Diary.ofTest(user, emotion, LocalDate.now(), null);
+        return Diary.ofTest(user, emotion, LocalDateTime.now(), null);
     }
 
     public static Diary createDiaryWithId(Long diaryId, User user, Emotion emotion) {

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -224,6 +225,7 @@ class DiaryControllerTest extends ControllerTestSetup {
         private final String notes = "notes";
         private final LocalDate diaryDate = LocalDate.now();
         private final Long emotionId = 1L;
+        private final LocalTime userTime = LocalTime.now();
 
         @Nested
         @DisplayName("content 값 중")
@@ -247,7 +249,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(LocalTime.class));
             }
 
             @Test
@@ -270,7 +273,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(LocalTime.class));
             }
 
             @Test
@@ -291,7 +295,8 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // then
                 result.andExpect(status().isBadRequest());
                 verify(createDiaryService, never()).createDiary(any(Long.class),
-                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class));
+                    any(Long.class), any(String.class), any(String.class), any(LocalDate.class),
+                    any(LocalTime.class));
             }
         }
 
@@ -305,7 +310,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // given
                 Long diaryId = 1L;
                 given(createDiaryService.createDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, userTime))
                     .willReturn(new CreateDiaryResponse(diaryId));
 
                 // when
@@ -331,7 +336,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 // given
                 Long testDiaryId = 1L;
                 given(createDiaryService.createTestDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate))
+                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, userTime))
                     .willReturn(new CreateDiaryResponse(testDiaryId));
 
                 // when

--- a/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/CreateDiaryServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,7 @@ class CreateDiaryServiceTest {
         private final String KEYWORD = "키워드";
         private final String NOTES = "노트";
         private final LocalDate DIARY_DATE = LocalDate.now();
+        private final LocalTime USER_TIME = LocalTime.now();
 
         @Nested
         @DisplayName("dallE 요청 시")
@@ -92,7 +94,7 @@ class CreateDiaryServiceTest {
                 //then
                 assertThatThrownBy(
                     () -> createDiaryService.createDiary(USER_ID, EMOTION_ID, KEYWORD, NOTES,
-                        DIARY_DATE)).isInstanceOf(exceptionClass);
+                        DIARY_DATE, USER_TIME)).isInstanceOf(exceptionClass);
                 assertThat(user.getLastDiaryDate().isEqual(lastDateTime)).isTrue();
 
                 verify(promptService).createPrompt(eq(prompt), eq(false));
@@ -122,7 +124,7 @@ class CreateDiaryServiceTest {
 
                 //when
                 CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, DIARY_DATE);
+                    USER_ID, EMOTION_ID, KEYWORD, NOTES, DIARY_DATE, USER_TIME);
 
                 //then
                 assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
@@ -145,6 +147,7 @@ class CreateDiaryServiceTest {
             //given
             Long userId = 1L;
             LocalDate diaryDate = LocalDate.now();
+            LocalTime userTime = LocalTime.now();
             Long emotionId = 1L;
             Long diaryId = 1L;
             String prompt = "test prompt";
@@ -165,7 +168,7 @@ class CreateDiaryServiceTest {
 
             //when
             CreateDiaryResponse response = createDiaryService.createTestDiary(
-                userId, emotionId, keyword, notes, diaryDate);
+                userId, emotionId, keyword, notes, diaryDate, userTime);
 
             //then
             assertThat(response.getId()).isEqualTo(diaryId);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- CreateDiaryRequest DTO에 userTime(요청하는 유저 로컬 시각) 추가
- GlobalExceptionHandler에서 HttpMessageNotReadableException을 잡아 커스텀 메시지를 반환하도록 추가
- 바뀐 시그니처에 따라 테스트 코드 수정

## 관련 이슈

close #184 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
