### PR TITLE
티켓 기반의 일기 생성 제한 검증 기능 그리고 관리자 일기 조회 테스트 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/controller/DiaryController.java
@@ -229,7 +229,7 @@ public class DiaryController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "일기 생성 가능 여부 조회", description = "유저가 일기를 생성할 수 있는지 여부를 반환한다.")
+    @Operation(summary = "일기 생성 가능 여부 조회", description = "유저가 일기를 생성할 수 있는 티켓이 있는지 여부를 반환한다.")
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",

--- a/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryLimitResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/dto/GetDiaryLimitResponse.java
@@ -28,11 +28,11 @@ public class GetDiaryLimitResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    @Schema(description = "유효 리워드 생성일자", requiredMode = RequiredMode.NOT_REQUIRED)
-    private LocalDateTime rewardCreatedAt;
+    @Schema(description = "유효 티켓 생성일자", requiredMode = RequiredMode.NOT_REQUIRED)
+    private LocalDateTime ticketCreatedAt;
 
     public static GetDiaryLimitResponse of(boolean available, LocalDateTime lastDiaryCreatedAt,
-        LocalDateTime rewardCreatedAt) {
-        return new GetDiaryLimitResponse(available, lastDiaryCreatedAt, rewardCreatedAt);
+        LocalDateTime ticketCreatedAt) {
+        return new GetDiaryLimitResponse(available, lastDiaryCreatedAt, ticketCreatedAt);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/diary/service/DiaryService.java
@@ -112,14 +112,10 @@ public class DiaryService {
         LocalDateTime lastDiaryDate = user.getLastDiaryDate();
         LocalDateTime ticketCreatedAt = null;
 
-        if (user.checkDrawLimit()) {
+        Optional<Ticket> ticket = validateTicketService.findValidTicket(userId);
+        if (ticket.isPresent()) {
             available = true;
-        } else {
-            Optional<Ticket> ticket = validateTicketService.findValidTicket(userId);
-            if (ticket.isPresent()) {
-                available = true;
-                ticketCreatedAt = ticket.get().getCreatedAt();
-            }
+            ticketCreatedAt = ticket.get().getCreatedAt();
         }
 
         return GetDiaryLimitResponse.of(available, lastDiaryDate, ticketCreatedAt);

--- a/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketQueryRepository.java
@@ -1,0 +1,9 @@
+package tipitapi.drawmytoday.ticket.repository;
+
+import java.util.Optional;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+
+public interface TicketQueryRepository {
+
+    Optional<Ticket> findValidTicket(Long userId);
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketQueryRepositoryImpl.java
@@ -1,0 +1,24 @@
+package tipitapi.drawmytoday.ticket.repository;
+
+import static tipitapi.drawmytoday.ticket.domain.QTicket.ticket;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+
+@RequiredArgsConstructor
+public class TicketQueryRepositoryImpl implements TicketQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Ticket> findValidTicket(Long userId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(ticket)
+                .where(ticket.usedAt.isNull()
+                    .and(ticket.user.userId.eq(userId)))
+                .orderBy(ticket.createdAt.asc())
+                .fetchFirst());
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/repository/TicketRepository.java
@@ -3,6 +3,6 @@ package tipitapi.drawmytoday.ticket.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.ticket.domain.Ticket;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long> {
+public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketQueryRepository {
 
 }

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/TicketService.java
@@ -28,6 +28,6 @@ public class TicketService {
 
     @Transactional
     public void createTicketByAdReward(User user) {
-        ticketRepository.save(Ticket.of(user, TicketType.AD_REWARD))
+        ticketRepository.save(Ticket.of(user, TicketType.AD_REWARD));
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/ticket/service/ValidateTicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/ticket/service/ValidateTicketService.java
@@ -1,0 +1,20 @@
+package tipitapi.drawmytoday.ticket.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.repository.TicketRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ValidateTicketService {
+
+    private final TicketRepository ticketRepository;
+
+    public Optional<Ticket> findValidTicket(Long userId) {
+        return ticketRepository.findValidTicket(userId);
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/admin/service/AdminServiceTest.java
@@ -22,7 +22,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Sort.Direction;
 import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.diary.service.AdminDiaryService;
-import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserAccessDeniedException;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
@@ -34,8 +33,6 @@ class AdminServiceTest {
     ValidateUserService validateUserService;
     @Mock
     AdminDiaryService adminDiaryService;
-    @Mock
-    S3PreSignedService s3PreSignedService;
     @InjectMocks
     AdminService adminService;
 
@@ -83,8 +80,6 @@ class AdminServiceTest {
                     LocalDateTime.of(2023, 6, 17, 15, 0, 0)));
                 given(adminDiaryService.getDiaries(any(Integer.class), any(Integer.class),
                     any(Direction.class), anyLong())).willReturn(new PageImpl<>(diaries));
-                given(s3PreSignedService.getPreSignedUrlForShare(any(String.class), anyLong()))
-                    .willReturn("imageUrl");
 
                 // when
                 Page<GetDiaryAdminResponse> response = adminService.getDiaries(1L, 10, 0,

--- a/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/controller/DiaryControllerTest.java
@@ -447,7 +447,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 .andExpect(jsonPath("$.data.available").value(true))
                 .andExpect(jsonPath("$.data.lastDiaryCreatedAt").value(
                     parseLocalDateTime(lastDiaryCreatedDate)))
-                .andExpect(jsonPath("$.data.rewardCreatedAt").value(
+                .andExpect(jsonPath("$.data.ticketCreatedAt").value(
                     parseLocalDateTime(validRewardCreatedDate)));
         }
     }

--- a/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/repository/DiaryRepositoryTest.java
@@ -231,6 +231,8 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
     @Nested
     @DisplayName("getDiariesForMonitorAsPage 메소드 테스트")
     class GetDiariesForMonitorAsPageTest {
+        // TODO: Diary 도메인의 @SQLDelete에 따른 @Where Clause 적용으로인해, queryDSL 기반 메서드임에도 삭제된 일기가 쿼리에서 제외됨. 그래서 아래 테스트 중 일부가 실패함.
+        //  따라서, diary 관련 레포지토리 메서드를 queryDSL 기반으로 변경한 후 @Where Clause 설정을 삭제해 개선해야함
 
         @Nested
         @DisplayName("삭제된 일기가 있을 경우")

--- a/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/AdminDiaryServiceTest.java
@@ -2,6 +2,9 @@ package tipitapi.drawmytoday.diary.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;
@@ -20,12 +23,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import tipitapi.drawmytoday.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
+import tipitapi.drawmytoday.s3.service.S3PreSignedService;
 
 @ExtendWith(MockitoExtension.class)
 class AdminDiaryServiceTest {
 
     @Mock
     DiaryRepository diaryRepository;
+    @Mock
+    S3PreSignedService s3PreSignedService;
     @InjectMocks
     AdminDiaryService adminDiaryService;
 
@@ -48,8 +54,11 @@ class AdminDiaryServiceTest {
                 LocalDateTime.of(2023, 6, 17, 15, 0, 0)));
             given(
                 diaryRepository.getDiariesForMonitorAsPage(any(Pageable.class),
-                    any(Direction.class), 1L))
+                    any(Direction.class), eq(1L)))
                 .willReturn(new PageImpl<>(diaries));
+            given(
+                s3PreSignedService.getPreSignedUrlForShare(anyString(), anyLong()))
+                .willReturn("https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png");
 
             // when
             Page<GetDiaryAdminResponse> response = adminDiaryService.getDiaries(10, 0,

--- a/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/diary/service/DiaryServiceTest.java
@@ -27,8 +27,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import tipitapi.drawmytoday.adreward.domain.AdReward;
-import tipitapi.drawmytoday.adreward.service.ValidateAdRewardService;
 import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.utils.Encryptor;
@@ -45,6 +43,9 @@ import tipitapi.drawmytoday.diary.exception.NotOwnerOfDiaryException;
 import tipitapi.drawmytoday.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.emotion.domain.Emotion;
 import tipitapi.drawmytoday.s3.service.S3PreSignedService;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.domain.TicketType;
+import tipitapi.drawmytoday.ticket.service.ValidateTicketService;
 import tipitapi.drawmytoday.user.domain.User;
 import tipitapi.drawmytoday.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.user.service.ValidateUserService;
@@ -67,7 +68,7 @@ class DiaryServiceTest {
     @Mock
     PromptService promptService;
     @Mock
-    ValidateAdRewardService validateAdRewardService;
+    ValidateTicketService validateTicketService;
     @InjectMocks
     DiaryService diaryService;
 
@@ -610,7 +611,7 @@ class DiaryServiceTest {
 
                 assertThat(response.isAvailable()).isTrue();
                 assertThat(response.getLastDiaryCreatedAt()).isNull();
-                assertThat(response.getRewardCreatedAt()).isNull();
+                assertThat(response.getTicketCreatedAt()).isNull();
             }
         }
 
@@ -631,7 +632,7 @@ class DiaryServiceTest {
 
                 assertThat(response.isAvailable()).isTrue();
                 assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
-                assertThat(response.getRewardCreatedAt()).isNull();
+                assertThat(response.getTicketCreatedAt()).isNull();
             }
         }
 
@@ -640,8 +641,8 @@ class DiaryServiceTest {
         class if_user_wrote_diary_today {
 
             @Nested
-            @DisplayName("유효한 리워드가 있을 경우")
-            class if_valid_reward_exists {
+            @DisplayName("유효한 티켓이 있을 경우")
+            class if_valid_ticket_exists {
 
                 @Test
                 @DisplayName("일기 생성 가능한 내용의 GetDrawLimitResponse 객체를 반환한다.")
@@ -650,25 +651,25 @@ class DiaryServiceTest {
                     LocalDateTime lastDiaryDate = LocalDateTime.now().minusMinutes(10);
                     user.setLastDiaryDate(lastDiaryDate);
 
-                    AdReward adReward = new AdReward(user);
-                    LocalDateTime rewardCreatedAt = LocalDateTime.now().minusMinutes(30);
-                    ReflectionTestUtils.setField(adReward, "createdAt", rewardCreatedAt);
+                    Ticket ticket = Ticket.of(user, TicketType.AD_REWARD);
+                    LocalDateTime ticketCreatedAt = LocalDateTime.now().minusMinutes(30);
+                    ReflectionTestUtils.setField(ticket, "createdAt", ticketCreatedAt);
 
                     given(validateUserService.validateUserById(1L)).willReturn(user);
-                    given(validateAdRewardService.findValidAdReward(1L)).willReturn(
-                        Optional.of(adReward));
+                    given(validateTicketService.findValidTicket(1L)).willReturn(
+                        Optional.of(ticket));
 
                     GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
 
                     assertThat(response.isAvailable()).isTrue();
                     assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
-                    assertThat(response.getRewardCreatedAt()).isEqualTo(rewardCreatedAt);
+                    assertThat(response.getTicketCreatedAt()).isEqualTo(ticketCreatedAt);
                 }
             }
 
             @Nested
-            @DisplayName("유효한 리워드가 없을 경우")
-            class if_valid_reward_not_exists {
+            @DisplayName("유효한 티켓이 없을 경우")
+            class if_valid_ticket_not_exists {
 
                 @Test
                 @DisplayName("일기 생성 불가한 내용의 GetDrawLimitResponse 객체를 반환한다.")
@@ -678,14 +679,14 @@ class DiaryServiceTest {
                     ReflectionTestUtils.setField(user, "lastDiaryDate", lastDiaryDate);
 
                     given(validateUserService.validateUserById(1L)).willReturn(user);
-                    given(validateAdRewardService.findValidAdReward(1L)).willReturn(
+                    given(validateTicketService.findValidTicket(1L)).willReturn(
                         Optional.empty());
 
                     GetDiaryLimitResponse response = diaryService.getDrawLimit(1L);
 
                     assertThat(response.isAvailable()).isFalse();
                     assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
-                    assertThat(response.getRewardCreatedAt()).isNull();
+                    assertThat(response.getTicketCreatedAt()).isNull();
                 }
             }
         }

--- a/src/test/java/tipitapi/drawmytoday/ticket/repository/TicketRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/ticket/repository/TicketRepositoryTest.java
@@ -1,0 +1,91 @@
+package tipitapi.drawmytoday.ticket.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.util.ReflectionTestUtils;
+import tipitapi.drawmytoday.common.BaseRepositoryTest;
+import tipitapi.drawmytoday.common.config.QuerydslConfig;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.domain.TicketType;
+import tipitapi.drawmytoday.user.domain.User;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(QuerydslConfig.class)
+public class TicketRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Nested
+    @DisplayName("findValidTicket 메소드 테스트")
+    class FindValidTicketTest {
+
+        @Nested
+        @DisplayName("등록된 티켓이 없을 경우")
+        class If_no_ticket_exists {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                User user = createUser();
+
+                Optional<Ticket> ticket = ticketRepository.findValidTicket(user.getUserId());
+
+                assertThat(ticket).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("등록된 티켓이 사용된 상태인 경우")
+        class If_ticket_is_used {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                User user = createUser();
+                Ticket ticket = Ticket.of(user, TicketType.JOIN);
+                ReflectionTestUtils.setField(ticket, "usedAt", LocalDateTime.now().minusDays(1));
+                ticketRepository.save(ticket);
+
+                Optional<Ticket> result = ticketRepository.findValidTicket(user.getUserId());
+
+                assertThat(result).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("유효한 티켓이 존재하는 경우")
+        class If_valid_ticket_exists {
+
+            @Nested
+            @DisplayName("여러개가 존재할 경우")
+            class If_multiple_valid_ticket_exists {
+
+                @Test
+                @DisplayName("가장 오래된 티켓을 반환한다.")
+                @Sql("ValidTicket.sql")
+                void return_oldest_ticket() {
+                    final Long userId = 1L;
+
+                    Optional<Ticket> ticket = ticketRepository.findValidTicket(userId);
+
+                    assertThat(ticket.isPresent()).isTrue();
+                    assertThat(ticket.get().getTicketId()).isEqualTo(2L);
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/tipitapi/drawmytoday/ticket/service/ValidateTicketServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/ticket/service/ValidateTicketServiceTest.java
@@ -1,0 +1,66 @@
+package tipitapi.drawmytoday.ticket.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static tipitapi.drawmytoday.common.testdata.TestUser.createUserWithId;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.ticket.domain.Ticket;
+import tipitapi.drawmytoday.ticket.domain.TicketType;
+import tipitapi.drawmytoday.ticket.repository.TicketRepository;
+import tipitapi.drawmytoday.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+public class ValidateTicketServiceTest {
+
+    @Mock
+    TicketRepository ticketRepository;
+    @InjectMocks
+    ValidateTicketService validateTicketService;
+
+    @Nested
+    @DisplayName("findValidTicket 메소드 테스트")
+    class FindValidTicketTest {
+
+        @Nested
+        @DisplayName("유효한 티켓이 존재하지 않을 경우")
+        class If_no_valid_ticket_exists {
+
+            @Test
+            @DisplayName("null를 반환한다.")
+            void return_null() {
+                given(ticketRepository.findValidTicket(anyLong())).willReturn(Optional.empty());
+
+                Optional<Ticket> ticket = validateTicketService.findValidTicket(1L);
+
+                assertThat(ticket).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("유효한 티켓이 존재할 경우")
+        class If_valid_ticket_exists {
+
+            @Test
+            @DisplayName("티켓을 반환한다.")
+            void return_ticket() {
+                User user = createUserWithId(1L);
+                Ticket ticket = Ticket.of(user, TicketType.JOIN);
+                given(ticketRepository.findValidTicket(anyLong())).willReturn(Optional.of(ticket));
+
+                Optional<Ticket> result = validateTicketService.findValidTicket(user.getUserId());
+
+                assertThat(result).isPresent();
+                assertThat(result.get()).isEqualTo(ticket);
+            }
+        }
+    }
+}

--- a/src/test/resources/tipitapi/drawmytoday/ticket/repository/ValidTicket.sql
+++ b/src/test/resources/tipitapi/drawmytoday/ticket/repository/ValidTicket.sql
@@ -1,0 +1,13 @@
+INSERT INTO `user` (user_id, created_at, updated_at, deleted_at, email, last_diary_date,
+                    social_code,
+                    user_role)
+VALUES (1, '2023-03-01T15:20:02.236278', '2023-03-01T15:20:02.236278', null, null, null, 'GOOGLE',
+        null);
+INSERT INTO `ticket` (ticket_id, created_at, ticket_type, used_at, user_id)
+VALUES (1, '2023-04-01T15:38:02.012342', 'JOIN', '2023-05-04T15:20:02.235513', 1);
+INSERT INTO `ticket` (ticket_id, created_at, ticket_type, used_at, user_id)
+VALUES (2, '2023-05-03T15:10:02.354232', 'JOIN', null, 1);
+INSERT INTO `ticket` (ticket_id, created_at, ticket_type, used_at, user_id)
+VALUES (3, '2023-06-20T09:29:02.534499', 'AD_REWARD', null, 1);
+INSERT INTO `ticket` (ticket_id, created_at, ticket_type, used_at, user_id)
+VALUES (4, '2023-06-28T13:00:02.236278', 'AD_REWARD', null, 1);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[GET] /diary/limit 일기 생성 가능 여부 조회 API : 광고가 아닌, 티켓 기반으로 일기 생성 제한을 검증하도록 수정
- 기존에는 오늘 작성할 수 있는 일기를 이미 작성했을 때, 유효한 광고 리워드가 있는지 검증했습니다.
- 이때, 유효한 광고 리워드가 아닌 유효한 티켓을 통해 검증하도록 수정하였습니다.
- 리워드라는 명칭을 지양하도록, 응답 필드명을 수정했습니다. : rewardCreatedAt -> ticketCreatedAt
- 티켓을 가지고 있는지 검증하는 메서드를, 단순히 있는지를 검사하기 보다 유효한지를 검증해야한다고 생각합니다. 현재는 티켓 만료에 대한 ( 유효기간에 대한 ) 기준이 정해지지 않았지만, 추후 확장될 것을 고려해서 Valid 네이밍을 사용하도록 했습니다.
   - 추후에는, TicketType(JOIN, AD_REWARD)에 따라 유효기간이 다르게 설정될것 같아 현재 적용하지 않은 점도 있습니다!
- 유저가 오늘 일기를 작성했는지 검증하지 않고, 유저가 티켓을 가지고 있는지 검증하도록 변경
   - 따라서, user의 lastDiaryDate에 대한 검증 로직을 삭제하였습니다.

관리자 일기 조회시 사용되는 메서드의 테스트 코드 수정
- 관리자 일기 조회 API 수행시 사용되는 메서드에 대한 테스트 코드가 잘못 작성되어 있어 수정하였습니다.

## 관련 이슈

close #185

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
