### PR TITLE
JACOCO 커버리지 Q파일 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,13 +90,18 @@ jacocoTestReport {
         xml.enabled false
         csv.enabled false
     }
+    def Qdomains = []
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
 
     afterEvaluate {
+
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
                 exclude: [
                     'tipitapi/drawmytoday/common/**'
-                ])
+                ] + Qdomains)
         }))
     }
 
@@ -104,6 +109,11 @@ jacocoTestReport {
 }
 
 jacocoTestCoverageVerification {
+
+    def Qdomains = []
+    for (qPattern in "*.QA".."*.QZ") {
+        Qdomains.add(qPattern + "*")
+    }
 
     violationRules {
         rule {
@@ -117,7 +127,7 @@ jacocoTestCoverageVerification {
 
             excludes = [
                 'tipitapi/drawmytoday/common/**'
-            ]
+            ] + Qdomains
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- JACOCO 커버리지에 Q파일 추적되는 이슈 해결

gradle로 테스트를 돌리면 jacoco 리포트가 작성됩니다.(jacocoTestReport task에 test를 dependsOn했기 때문입니다) 다만, 테스트가 하나라도 실패한다면 리포트는 작성되지 않습니다. 따라서 실패하는 테스트가 있다면 잠시 주석처리를 한다면 리포트를 확인할 수 있습니다.

리포트는 build/reports/jacoco/test/html/index.html에서 확인하실 수 있습니다.

## 관련 이슈

close #204 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
