### PR TITLE
OAuthService 리팩토링 및 User 엔티티 email 필드 not nullable

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     HANDLE_ACCESS_DENIED(403, "C006", "접근이 거부됐습니다."),
     ENCRYPTION_ERROR(500, "C007", "암호화에 실패했습니다."),
     DECRYPTION_ERROR(500, "C008", "복호화에 실패했습니다."),
+    OBJECT_MAPPING_ERROR(500, "C009", "객체 매핑에 실패했습니다."),
 
     // Security
     AUTHORITY_NOT_FOUND(404, "S001", "유저 권한이 없습니다."),

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     HANDLE_ACCESS_DENIED(403, "C006", "접근이 거부됐습니다."),
     ENCRYPTION_ERROR(500, "C007", "암호화에 실패했습니다."),
     DECRYPTION_ERROR(500, "C008", "복호화에 실패했습니다."),
-    OBJECT_MAPPING_ERROR(500, "C009", "객체 매핑에 실패했습니다."),
+    PARSING_ERROR(500, "C009", "파싱에 실패했습니다."),
 
     // Security
     AUTHORITY_NOT_FOUND(404, "S001", "유저 권한이 없습니다."),

--- a/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
@@ -39,7 +39,7 @@ public class HeaderUtils {
         return tokens[1];
     }
 
-    public static String getAuthorizationHeader(HttpServletRequest request) {
+    public static String getAuthCode(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
         if (!StringUtils.hasText(authorization)) {
             throw new TokenNotFoundException(ErrorCode.AUTH_CODE_NOT_FOUND);

--- a/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/HeaderUtils.java
@@ -38,4 +38,17 @@ public class HeaderUtils {
 
         return tokens[1];
     }
+
+    public static String getAuthorizationHeader(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (!StringUtils.hasText(authorization)) {
+            throw new TokenNotFoundException(ErrorCode.AUTH_CODE_NOT_FOUND);
+        }
+
+        String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
+        if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {
+            throw new InvalidTokenException();
+        }
+        return tokens[1];
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/controller/AuthController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/controller/AuthController.java
@@ -1,13 +1,11 @@
 package tipitapi.drawmytoday.domain.oauth.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -61,8 +59,8 @@ public class AuthController {
             content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping(value = "/google/login")
-    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleLogin(HttpServletRequest request)
-        throws JsonProcessingException {
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleLogin(
+        HttpServletRequest request) {
         return SuccessResponse.of(
             googleOAuthService.login(request)
         ).asHttp(HttpStatus.OK);
@@ -88,7 +86,7 @@ public class AuthController {
     })
     @PostMapping(value = "/apple/login")
     public ResponseEntity<SuccessResponse<ResponseJwtToken>> appleLogin(HttpServletRequest request,
-        @RequestBody @Valid RequestAppleLogin requestAppleLogin) throws IOException {
+        @RequestBody @Valid RequestAppleLogin requestAppleLogin) {
         return SuccessResponse.of(
             appleOAuthService.login(request, requestAppleLogin)
         ).asHttp(HttpStatus.OK);

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/domain/Auth.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/domain/Auth.java
@@ -32,9 +32,13 @@ public class Auth extends BaseEntity {
     @Column(nullable = false)
     private String refreshToken;
 
-    public Auth(User user, String refreshToken) {
+    private Auth(User user, String refreshToken) {
         this.user = user;
         this.refreshToken = refreshToken;
+    }
+
+    public static Auth create(User user, String refreshToken) {
+        return new Auth(user, refreshToken);
     }
 
     public void setRefreshToken(String refreshToken) {

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -66,9 +66,8 @@ public class AppleOAuthService {
             Auth auth = authRepository.findByUser(user).orElseThrow(OAuthNotFoundException::new);
             auth.setRefreshToken(oAuthAccessToken.getRefreshToken());
         } else {
-            user = userService.registerUser(appleIdToken.getEmail(), SocialCode.APPLE);
-            authRepository.save(new Auth(user, oAuthAccessToken.getRefreshToken()));
-            ticketService.createTicketByJoin(user);
+            user = userService.registerUser(
+                appleIdToken.getEmail(), SocialCode.APPLE, oAuthAccessToken.getRefreshToken());
         }
 
         String jwtAccessToken = jwtTokenProvider.createAccessToken(user.getUserId(),

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -93,7 +93,7 @@ public class AppleOAuthService {
     }
 
     private OAuthAccessToken getAccessToken(HttpServletRequest request) {
-        String authorizationCode = HeaderUtils.getAuthorizationHeader(request);
+        String authorizationCode = HeaderUtils.getAuthCode(request);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.domain.oauth.service;
 
-import static tipitapi.drawmytoday.common.exception.ErrorCode.AUTH_CODE_NOT_FOUND;
 import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.OBJECT_MAPPING_ERROR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,12 +17,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
-import tipitapi.drawmytoday.common.security.jwt.exception.InvalidTokenException;
-import tipitapi.drawmytoday.common.security.jwt.exception.TokenNotFoundException;
+import tipitapi.drawmytoday.common.utils.HeaderUtils;
 import tipitapi.drawmytoday.domain.oauth.domain.Auth;
 import tipitapi.drawmytoday.domain.oauth.dto.AppleIdToken;
 import tipitapi.drawmytoday.domain.oauth.dto.OAuthAccessToken;
@@ -31,7 +29,6 @@ import tipitapi.drawmytoday.domain.oauth.dto.ResponseJwtToken;
 import tipitapi.drawmytoday.domain.oauth.exception.OAuthNotFoundException;
 import tipitapi.drawmytoday.domain.oauth.properties.AppleProperties;
 import tipitapi.drawmytoday.domain.oauth.repository.AuthRepository;
-import tipitapi.drawmytoday.domain.ticket.service.TicketService;
 import tipitapi.drawmytoday.domain.user.domain.SocialCode;
 import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.service.UserService;
@@ -49,23 +46,16 @@ public class AppleOAuthService {
     private final UserService userService;
     private final AuthRepository authRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final TicketService ticketService;
 
     @Transactional
-    public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin)
-        throws IOException {
-        String authorizationCode = getAuthorizationCode(request);
-
-        OAuthAccessToken oAuthAccessToken = getRefreshToken(authorizationCode);
-
+    public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin) {
+        OAuthAccessToken oAuthAccessToken = getRefreshToken(request);
         AppleIdToken appleIdToken = getAppleIdToken(requestAppleLogin.getIdToken());
 
         User user = validateUserService.validateRegisteredUserByEmail(
             appleIdToken.getEmail(), SocialCode.APPLE);
-        if (user != null) {
-            Auth auth = authRepository.findByUser(user).orElseThrow(OAuthNotFoundException::new);
-            auth.setRefreshToken(oAuthAccessToken.getRefreshToken());
-        } else {
+
+        if (user == null) {
             user = userService.registerUser(
                 appleIdToken.getEmail(), SocialCode.APPLE, oAuthAccessToken.getRefreshToken());
         }
@@ -81,7 +71,6 @@ public class AppleOAuthService {
     @Transactional
     public void deleteAccount(User user) {
         Auth auth = authRepository.findByUser(user).orElseThrow(OAuthNotFoundException::new);
-        String refreshToken = auth.getRefreshToken();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -89,13 +78,12 @@ public class AppleOAuthService {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("client_id", properties.getClientId());
         body.add("client_secret", properties.getClientSecret());
-        body.add("token", refreshToken);
+        body.add("token", auth.getRefreshToken());
         body.add("token_type_hint", "refresh_token");
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
         String url = properties.getDeleteAccountUrl();
-
         String response = restTemplate.postForObject(url, request, String.class);
         if (response != null) {
             throw new BusinessException(OAUTH_SERVER_FAILED);
@@ -104,45 +92,37 @@ public class AppleOAuthService {
         user.deleteUser();
     }
 
-    private OAuthAccessToken getRefreshToken(String authorizationCode)
-        throws JsonProcessingException {
+    private OAuthAccessToken getRefreshToken(HttpServletRequest request) {
+        String authorizationCode = HeaderUtils.getAuthorizationHeader(request);
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        String clientId = properties.getClientId();
-        String clientSecret = properties.getClientSecret();
-        String appleTokenUrl = properties.getTokenUrl();
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("code", authorizationCode);
-        body.add("client_id", clientId);
-        body.add("client_secret", clientSecret);
+        body.add("client_id", properties.getClientId());
+        body.add("client_secret", properties.getClientSecret());
         HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
-        ResponseEntity<String> response = restTemplate.postForEntity(appleTokenUrl, entity,
-            String.class);
 
-        String tokenResponse = response.getBody();
-        return objectMapper.readValue(tokenResponse, OAuthAccessToken.class);
+        ResponseEntity<String> response = restTemplate.postForEntity(
+            properties.getTokenUrl(), entity, String.class);
+
+        try {
+            return objectMapper.readValue(response.getBody(), OAuthAccessToken.class);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+        }
     }
 
-    private AppleIdToken getAppleIdToken(String idToken) throws IOException {
+    private AppleIdToken getAppleIdToken(String idToken) {
         String[] jwtParts = idToken.split("\\.");
         byte[] bytes = Base64.getDecoder().decode(jwtParts[1].getBytes());
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(bytes, AppleIdToken.class);
+        try {
+            return objectMapper.readValue(bytes, AppleIdToken.class);
+        } catch (IOException e) {
+            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+        }
     }
 
-    private String getAuthorizationCode(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization");
-        if (!StringUtils.hasText(authorization)) {
-            throw new TokenNotFoundException(AUTH_CODE_NOT_FOUND);
-        }
-
-        String[] tokens = StringUtils.delimitedListToStringArray(authorization, " ");
-        if (tokens.length != 2 || !"Bearer".equals(tokens[0])) {
-            throw new InvalidTokenException();
-        }
-        return tokens[1];
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -49,7 +49,7 @@ public class AppleOAuthService {
 
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin) {
-        OAuthAccessToken oAuthAccessToken = getRefreshToken(request);
+        OAuthAccessToken oAuthAccessToken = getAccessToken(request);
         AppleIdToken appleIdToken = getAppleIdToken(requestAppleLogin.getIdToken());
 
         User user = validateUserService.validateRegisteredUserByEmail(
@@ -92,7 +92,7 @@ public class AppleOAuthService {
         user.deleteUser();
     }
 
-    private OAuthAccessToken getRefreshToken(HttpServletRequest request) {
+    private OAuthAccessToken getAccessToken(HttpServletRequest request) {
         String authorizationCode = HeaderUtils.getAuthorizationHeader(request);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -1,7 +1,7 @@
 package tipitapi.drawmytoday.domain.oauth.service;
 
 import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
-import static tipitapi.drawmytoday.common.exception.ErrorCode.OBJECT_MAPPING_ERROR;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.PARSING_ERROR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -111,7 +111,7 @@ public class AppleOAuthService {
         try {
             return objectMapper.readValue(response.getBody(), OAuthAccessToken.class);
         } catch (JsonProcessingException e) {
-            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+            throw new BusinessException(PARSING_ERROR, e);
         }
     }
 
@@ -121,7 +121,7 @@ public class AppleOAuthService {
         try {
             return objectMapper.readValue(bytes, AppleIdToken.class);
         } catch (IOException e) {
-            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+            throw new BusinessException(PARSING_ERROR, e);
         }
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
@@ -1,12 +1,9 @@
 package tipitapi.drawmytoday.domain.oauth.service;
 
 import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
-import static tipitapi.drawmytoday.common.exception.ErrorCode.OBJECT_MAPPING_ERROR;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.PARSING_ERROR;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -17,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
 import tipitapi.drawmytoday.common.utils.HeaderUtils;
@@ -116,7 +116,7 @@ public class GoogleOAuthService {
         try {
             return objectMapper.readValue(response.getBody(), OAuthAccessToken.class);
         } catch (JsonProcessingException e) {
-            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+            throw new BusinessException(PARSING_ERROR, e);
         }
     }
 
@@ -134,7 +134,7 @@ public class GoogleOAuthService {
         try {
             return objectMapper.readValue(userInfoResponse.getBody(), OAuthUserProfile.class);
         } catch (JsonProcessingException e) {
-            throw new BusinessException(OBJECT_MAPPING_ERROR, e);
+            throw new BusinessException(PARSING_ERROR, e);
         }
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
@@ -3,7 +3,10 @@ package tipitapi.drawmytoday.domain.oauth.service;
 import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
 import static tipitapi.drawmytoday.common.exception.ErrorCode.PARSING_ERROR;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -14,9 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenProvider;
 import tipitapi.drawmytoday.common.utils.HeaderUtils;
@@ -88,7 +88,7 @@ public class GoogleOAuthService {
         String url = properties.getDeleteAccountUrl();
         String response = restTemplate.postForObject(url, request, String.class);
 
-        if (response != null && response.contains("error")) {
+        if (response.contains("error")) {
             throw new BusinessException(OAUTH_SERVER_FAILED);
         }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
@@ -96,7 +96,7 @@ public class GoogleOAuthService {
     }
 
     private OAuthAccessToken getAccessToken(HttpServletRequest request) {
-        String authorizationCode = HeaderUtils.getAuthorizationHeader(request);
+        String authorizationCode = HeaderUtils.getAuthCode(request);
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Content-Type", "application/x-www-form-urlencoded");

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/GoogleOAuthService.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -33,7 +32,6 @@ import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.service.UserService;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -51,7 +49,7 @@ public class GoogleOAuthService {
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request) {
         OAuthAccessToken accessToken = getAccessToken(request);
-        log.info("accessToken: {}", accessToken.getRefreshToken());
+
         OAuthUserProfile oAuthUserProfile = getUserProfile(accessToken);
 
         User user = validateUserService.validateRegisteredUserByEmail(
@@ -99,7 +97,7 @@ public class GoogleOAuthService {
 
     private OAuthAccessToken getAccessToken(HttpServletRequest request) {
         String authorizationCode = HeaderUtils.getAuthorizationHeader(request);
-        log.info("authorizationCode: {}", authorizationCode);
+
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Content-Type", "application/x-www-form-urlencoded");
         MultiValueMap<String, String> httpBody = new LinkedMultiValueMap<>();
@@ -116,7 +114,6 @@ public class GoogleOAuthService {
             properties.getTokenUrl(), requestToken, String.class);
 
         try {
-            log.info("response: {}", response.getBody());
             return objectMapper.readValue(response.getBody(), OAuthAccessToken.class);
         } catch (JsonProcessingException e) {
             throw new BusinessException(OBJECT_MAPPING_ERROR, e);

--- a/src/main/java/tipitapi/drawmytoday/domain/user/domain/User.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/user/domain/User.java
@@ -27,6 +27,8 @@ public class User extends BaseEntityWithUpdate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    @NotNull
+    @Column(nullable = false)
     private String email;
 
     @NotNull

--- a/src/main/java/tipitapi/drawmytoday/domain/user/service/UserService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/user/service/UserService.java
@@ -3,6 +3,9 @@ package tipitapi.drawmytoday.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.domain.oauth.domain.Auth;
+import tipitapi.drawmytoday.domain.oauth.repository.AuthRepository;
+import tipitapi.drawmytoday.domain.ticket.service.TicketService;
 import tipitapi.drawmytoday.domain.user.domain.SocialCode;
 import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.repository.UserRepository;
@@ -13,13 +16,17 @@ import tipitapi.drawmytoday.domain.user.repository.UserRepository;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final AuthRepository authRepository;
+    private final TicketService ticketService;
 
     @Transactional
-    public User registerUser(String email, SocialCode socialCode) {
-        User user = User.builder()
+    public User registerUser(String email, SocialCode socialCode, String refreshToken) {
+        User user = userRepository.save(User.builder()
             .email(email)
             .socialCode(socialCode)
-            .build();
-        return userRepository.save(user);
+            .build());
+        authRepository.save(Auth.create(user, refreshToken));
+        ticketService.createTicketByJoin(user);
+        return user;
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- auth 도메인 서비스단 리팩토링
  - 로그인시 authorization 헤더에서 값을 가져오는 로직, 회원가입하는 로직 분리
  - Checked Exception -> UnChecked Exception으로 변환
- User 엔티티 email 필드 NotNull 추가

테스트 서버에 추가했으며 실서버 배포시 추가되어야 합니다.

```SQL
ALTER TABLE user MODIFY email VARCHAR(255) NOT NULL;
```

## 관련 이슈

close #132 
close #214 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
