### PR TITLE
감정 목록 조회 API Language enum 적용

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
@@ -52,11 +53,8 @@ public class EmotionController {
     public ResponseEntity<SuccessResponse<List<GetActiveEmotionsResponse>>> getAllEmotions(
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
         @Parameter(description = "반환 언어(ko/en)", in = ParameterIn.QUERY)
-        @RequestParam(value = "lan", required = false, defaultValue = "ko") String language
+        @RequestParam(name = "lan", required = false, defaultValue = "ko") Language language
     ) {
-        if (!language.matches("^(ko|en)$")) {
-            language = "ko";
-        }
         return SuccessResponse.of(
             emotionService.getActiveEmotions(tokenInfo.getUserId(), language)
         ).asHttp(HttpStatus.OK);

--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 
 @Getter
@@ -27,7 +28,7 @@ public class GetActiveEmotionsResponse {
     }
 
     public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions,
-        String language) {
+        Language language) {
         return emotions.stream()
             .map(e -> GetActiveEmotionsResponse.of(
                 e.getEmotionId(), getEmotionName(language, e), e.getColor()))
@@ -35,8 +36,8 @@ public class GetActiveEmotionsResponse {
                 Collectors.toList());
     }
 
-    private static String getEmotionName(String language, Emotion emotion) {
-        if (language.equals("ko")) {
+    private static String getEmotionName(Language language, Emotion emotion) {
+        if (Language.ko.equals(language)) {
             return emotion.getName();
         } else {
             return emotion.getEmotionPrompt();

--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/service/EmotionService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/service/EmotionService.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionRequest;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.domain.emotion.dto.GetActiveEmotionsResponse;
@@ -20,7 +21,7 @@ public class EmotionService {
     private final ValidateUserService validateUserService;
 
 
-    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId, String language) {
+    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId, Language language) {
         validateUserService.validateUserById(userId);
         return GetActiveEmotionsResponse.buildWithEmotions(
             emotionRepository.findAllActiveEmotions(), language);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/EmotionServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionRequest;
@@ -55,7 +56,7 @@ public class EmotionServiceTest {
                 given(validateUserService.validateUserById(1L)).willThrow(
                     new UserNotFoundException());
 
-                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L, "ko"))
+                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L, Language.ko))
                     .isInstanceOf(UserNotFoundException.class);
             }
         }
@@ -74,7 +75,7 @@ public class EmotionServiceTest {
                 given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
 
                 List<GetActiveEmotionsResponse> emotions =
-                    emotionService.getActiveEmotions(1L, "ko");
+                    emotionService.getActiveEmotions(1L, Language.ko);
 
                 assertThat(emotions.get(0).getId()).isEqualTo(activeEmotion.getEmotionId());
                 assertThat(emotions).extracting(GetActiveEmotionsResponse::getId)
@@ -95,7 +96,7 @@ public class EmotionServiceTest {
                 given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
 
                 List<GetActiveEmotionsResponse> emotions =
-                    emotionService.getActiveEmotions(1L, "en");
+                    emotionService.getActiveEmotions(1L, Language.en);
 
                 assertThat(emotions.get(0).getName()).isEqualTo(activeEmotion.getEmotionPrompt());
             }

--- a/src/test/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionControllerTest.java
@@ -33,6 +33,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.ResultActions;
 import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
 import tipitapi.drawmytoday.common.controller.WithCustomUser;
+import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.domain.emotion.dto.GetActiveEmotionsResponse;
 import tipitapi.drawmytoday.domain.emotion.service.EmotionService;
@@ -74,8 +75,8 @@ class EmotionControllerTest extends ControllerTestSetup {
                 //given
                 String language = "ko";
                 List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), language);
-                given(emotionService.getActiveEmotions(any(Long.class), any(String.class)))
+                    List.of(createEmotion(), createEmotion()), Language.ko);
+                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
                     .willReturn(emotionResponses);
 
                 //when
@@ -100,8 +101,8 @@ class EmotionControllerTest extends ControllerTestSetup {
                 //given
                 String language = "en";
                 List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), language);
-                given(emotionService.getActiveEmotions(any(Long.class), any(String.class)))
+                    List.of(createEmotion(), createEmotion()), Language.en);
+                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
                     .willReturn(emotionResponses);
 
                 //when
@@ -126,8 +127,8 @@ class EmotionControllerTest extends ControllerTestSetup {
                 //given
                 String language = "hello";
                 List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), "ko");
-                given(emotionService.getActiveEmotions(any(Long.class), any(String.class)))
+                    List.of(createEmotion(), createEmotion()), Language.ko);
+                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
                     .willReturn(emotionResponses);
 
                 //when
@@ -151,8 +152,8 @@ class EmotionControllerTest extends ControllerTestSetup {
             void not_query_parameter_than_return_korean_emotion() throws Exception {
                 //given
                 List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), "ko");
-                given(emotionService.getActiveEmotions(any(Long.class), any(String.class)))
+                    List.of(createEmotion(), createEmotion()), Language.ko);
+                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
                     .willReturn(emotionResponses);
 
                 //when


### PR DESCRIPTION
# 구현 내용

## 구현 요약

감정 목록 조회 API Language enum 적용
- String으로 lan 파라미터 값을 처리하는 로직 제거

## 관련 이슈

close #221 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
