### PR TITLE
Dalle 요청 로직 분리 및 서비스단 테스트 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/exception/DallEPolicyViolationException.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/exception/DallEPolicyViolationException.java
@@ -1,0 +1,9 @@
+package tipitapi.drawmytoday.domain.dalle.exception;
+
+public class DallEPolicyViolationException extends DallEException {
+
+    public DallEPolicyViolationException(String message) {
+        super(message);
+    }
+}
+정

--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/exception/DallEPolicyViolationException.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/exception/DallEPolicyViolationException.java
@@ -6,4 +6,3 @@ public class DallEPolicyViolationException extends DallEException {
         super(message);
     }
 }
-정

--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
@@ -1,0 +1,84 @@
+package tipitapi.drawmytoday.domain.dalle.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.domain.dalle.dto.CreateImageRequest;
+import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
+import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
+import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
+
+@Service
+@Transactional(readOnly = true)
+public class DallERequestService {
+
+    private final RestTemplate restTemplate;
+    private final String apiUrl;
+    private final HttpHeaders requestHeader;
+
+    public DallERequestService(@Qualifier("openaiRestTemplate") RestTemplate restTemplate,
+        @Value("${openai.dalle.url}") String apiUrl) {
+        this.restTemplate = restTemplate;
+        this.apiUrl = apiUrl;
+        this.requestHeader = new HttpHeaders() {
+            {
+                setContentType(MediaType.APPLICATION_JSON);
+            }
+        };
+    }
+
+    byte[] getImageAsUrl(String prompt)
+        throws DallERequestFailException, ImageInputStreamFailException {
+        try {
+            HttpEntity<CreateImageRequest> request = getRequest(CreateImageRequest.withUrl(prompt));
+
+            String url = Optional.ofNullable(
+                    restTemplate.postForObject(apiUrl, request, DallEUrlResponse.class)
+                ).orElseThrow(DallERequestFailException::new)
+                .getUrl(0);
+            return new URL(url).openStream().readAllBytes();
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.BAD_REQUEST && isContentPolicyError(e)) {
+                return null;
+            }
+            throw new DallERequestFailException(e);
+        } catch (IOException e) {
+            throw new ImageInputStreamFailException();
+        }
+    }
+
+    private boolean isContentPolicyError(HttpClientErrorException e)
+        throws DallERequestFailException {
+        String responseBody = e.getResponseBodyAsString();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+            JsonNode errorNode = rootNode.path("error");
+            if (errorNode.isObject()) {
+                String code = errorNode.path("code").asText();
+                return code != null && code.equals("content_policy_violation");
+            }
+        } catch (IOException ioException) {
+            throw new DallERequestFailException(ioException);
+        }
+        return false;
+    }
+
+    private HttpEntity<CreateImageRequest> getRequest(CreateImageRequest requestDto) {
+        return new HttpEntity<>(requestDto, requestHeader);
+    }
+
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
@@ -17,6 +17,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import tipitapi.drawmytoday.domain.dalle.dto.CreateImageRequest;
 import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
+import tipitapi.drawmytoday.domain.dalle.exception.DallEException;
+import tipitapi.drawmytoday.domain.dalle.exception.DallEPolicyViolationException;
 import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
 
@@ -39,8 +41,7 @@ public class DallERequestService {
         };
     }
 
-    byte[] getImageAsUrl(String prompt)
-        throws DallERequestFailException, ImageInputStreamFailException {
+    byte[] getImageAsUrl(String prompt) throws DallEException {
         try {
             HttpEntity<CreateImageRequest> request = getRequest(CreateImageRequest.withUrl(prompt));
 
@@ -51,7 +52,7 @@ public class DallERequestService {
             return new URL(url).openStream().readAllBytes();
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() == HttpStatus.BAD_REQUEST && isContentPolicyError(e)) {
-                return null;
+                throw new DallEPolicyViolationException(e.getResponseBodyAsString());
             }
             throw new DallERequestFailException(e);
         } catch (IOException e) {

--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -23,6 +24,7 @@ import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
 
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 public class DallERequestService {
 
@@ -52,6 +54,7 @@ public class DallERequestService {
             return new URL(url).openStream().readAllBytes();
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() == HttpStatus.BAD_REQUEST && isContentPolicyError(e)) {
+                log.warn("DallE 정책 위반 에러. prompt: {}", prompt);
                 throw new DallEPolicyViolationException(e.getResponseBodyAsString());
             }
             throw new DallERequestFailException(e);

--- a/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallEService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/dalle/service/DallEService.java
@@ -1,54 +1,23 @@
 package tipitapi.drawmytoday.domain.dalle.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Optional;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
-import tipitapi.drawmytoday.domain.dalle.dto.CreateImageRequest;
-import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
 import tipitapi.drawmytoday.domain.dalle.dto.GeneratedImageAndPrompt;
 import tipitapi.drawmytoday.domain.dalle.exception.DallEException;
 import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
-import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class DallEService {
 
-    private final RestTemplate restTemplate;
-    private final String apiUrl;
-    private final HttpHeaders requestHeader;
     private final PromptTextService promptTextService;
     private final PromptService promptService;
-
-
-    public DallEService(@Qualifier("openaiRestTemplate") RestTemplate restTemplate,
-        @Value("${openai.dalle.url}") String apiUrl, PromptTextService promptTextService,
-        PromptService promptService) {
-        this.restTemplate = restTemplate;
-        this.apiUrl = apiUrl;
-        this.requestHeader = new HttpHeaders() {
-            {
-                setContentType(MediaType.APPLICATION_JSON);
-            }
-        };
-        this.promptTextService = promptTextService;
-        this.promptService = promptService;
-    }
+    private final DallERequestService dalleRequestService;
 
     @Transactional(noRollbackFor = DallEException.class)
     public GeneratedImageAndPrompt generateImage(Emotion emotion, String keyword)
@@ -56,12 +25,12 @@ public class DallEService {
         String prompt = promptTextService.createPromptText(emotion, keyword);
 
         try {
-            byte[] image = getImageAsUrl(prompt);
+            byte[] image = dalleRequestService.getImageAsUrl(prompt);
 
             if (image == null) {
                 promptService.createPrompt(prompt, false);
                 prompt = promptTextService.createPromptText(emotion, null);
-                image = getImageAsUrl(prompt);
+                image = dalleRequestService.getImageAsUrl(prompt);
 
                 if (image == null) { // 재시도하였음에도, 컨텐츠 정책 위반 에러가 발생할경우 이미지 생성 실패 처리
                     throw DallERequestFailException.violatePolicy();
@@ -75,45 +44,4 @@ public class DallEService {
         }
     }
 
-    private byte[] getImageAsUrl(String prompt)
-        throws DallERequestFailException, ImageInputStreamFailException {
-        try {
-            HttpEntity<CreateImageRequest> request = getRequest(CreateImageRequest.withUrl(prompt));
-
-            String url = Optional.ofNullable(
-                    restTemplate.postForObject(apiUrl, request, DallEUrlResponse.class)
-                ).orElseThrow(DallERequestFailException::new)
-                .getUrl(0);
-            return new URL(url).openStream().readAllBytes();
-        } catch (HttpClientErrorException e) {
-            if (e.getStatusCode() == HttpStatus.BAD_REQUEST && isContentPolicyError(e)) {
-                return null;
-            }
-            throw new DallERequestFailException(e);
-        } catch (IOException e) {
-            throw new ImageInputStreamFailException();
-        }
-    }
-
-    private boolean isContentPolicyError(HttpClientErrorException e)
-        throws DallERequestFailException {
-        String responseBody = e.getResponseBodyAsString();
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        try {
-            JsonNode rootNode = objectMapper.readTree(responseBody);
-            JsonNode errorNode = rootNode.path("error");
-            if (errorNode.isObject()) {
-                String code = errorNode.path("code").asText();
-                return code != null && code.equals("content_policy_violation");
-            }
-        } catch (IOException ioException) {
-            throw new DallERequestFailException(ioException);
-        }
-        return false;
-    }
-
-    private HttpEntity<CreateImageRequest> getRequest(CreateImageRequest requestDto) {
-        return new HttpEntity<>(requestDto, requestHeader);
-    }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestServiceTest.java
@@ -1,0 +1,142 @@
+package tipitapi.drawmytoday.domain.dalle.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
+import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse.DallEUrl;
+import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
+import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
+
+@ExtendWith(MockitoExtension.class)
+class DallERequestServiceTest {
+
+    @Mock
+    RestTemplate restTemplate;
+    String apiUrl = "dalle-api-url";
+    DallERequestService dalleRequestService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.dalleRequestService = new DallERequestService(restTemplate, apiUrl);
+    }
+
+    @Nested
+    @DisplayName("getImageAsUrl 메서드 테스트")
+    class GetImageAsUrl_test {
+
+        @Nested
+        @DisplayName("DallE 요청을 보내고")
+        class Send_dallE_request {
+
+            @Test
+            @DisplayName("응답이 없으면 예외를 던진다")
+            void when_response_is_null_then_throw_exception() {
+                // given
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(null);
+
+                // when
+                // then
+                assertThatThrownBy(() -> dalleRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(DallERequestFailException.class);
+            }
+
+            @Test
+            @DisplayName("정책 위반 응답이 오면 null을 반환한다")
+            void when_response_is_content_policy_error_then_return_null() throws Exception {
+                // given
+                String responsebody = "{\n"
+                    + "  \"error\": {\n"
+                    + "    \"code\": \"content_policy_violation\",\n"
+                    + "    \"message\": \"Your request was rejected as a result of our safety system. Your prompt may contain text that is not allowed by our safety system.\",\n"
+                    + "    \"param\": null,\n"
+                    + "    \"type\": \"invalid_request_error\"\n"
+                    + "  }\n"
+                    + "}\n";
+                HttpClientErrorException badRequest = new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "bad request",
+                    responsebody.getBytes(StandardCharsets.UTF_8),
+                    StandardCharsets.UTF_8);
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willThrow(badRequest);
+
+                // when
+                byte[] image = dalleRequestService.getImageAsUrl("prompt");
+
+                // then
+                assertThat(image).isNull();
+            }
+
+            @Test
+            @DisplayName("정책 위반이 아닌 비정상적인 응답이 오면 예외를 던진다")
+            void when_invalid_response_then_throw_exception() throws Exception {
+                // given
+                HttpClientErrorException badRequest = new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST, "bad request");
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willThrow(badRequest);
+
+                // when
+                // then
+                assertThatThrownBy(() -> dalleRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(DallERequestFailException.class);
+            }
+
+            @Test
+            @DisplayName("응답받은 url에 해당하는 이미지를 가져올 수 없다면 예외를 던진다")
+            void when_get_image_fail_then_throw_exception() {
+                // given
+                DallEUrlResponse response = new DallEUrlResponse();
+                DallEUrl dallEUrl = new DallEUrl();
+                ReflectionTestUtils.setField(dallEUrl, "url", "invalid-url");
+                ReflectionTestUtils.setField(response, "data", List.of(dallEUrl));
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(response);
+
+                // when
+                // then
+                assertThatThrownBy(() -> dalleRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(ImageInputStreamFailException.class);
+            }
+
+            @Test
+            @DisplayName("응답 파싱에 성공하면 url을 반환한다")
+            void when_response_parsing_success_then_return_url() throws Exception {
+                // given
+                DallEUrlResponse response = new DallEUrlResponse();
+                DallEUrl dallEUrl = new DallEUrl();
+                ReflectionTestUtils.setField(dallEUrl, "url", "https://google.com");
+                ReflectionTestUtils.setField(response, "data", List.of(dallEUrl));
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(response);
+
+                // when
+                byte[] image = dalleRequestService.getImageAsUrl("prompt");
+
+                // then
+                assertThat(image).isNotEmpty();
+            }
+        }
+    }
+
+}

--- a/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallERequestServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
 import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse.DallEUrl;
+import tipitapi.drawmytoday.domain.dalle.exception.DallEPolicyViolationException;
 import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.domain.dalle.exception.ImageInputStreamFailException;
 
@@ -61,7 +62,7 @@ class DallERequestServiceTest {
             }
 
             @Test
-            @DisplayName("정책 위반 응답이 오면 null을 반환한다")
+            @DisplayName("정책 위반 응답이 오면 예외를 던진다.")
             void when_response_is_content_policy_error_then_return_null() throws Exception {
                 // given
                 String responsebody = "{\n"
@@ -81,10 +82,9 @@ class DallERequestServiceTest {
                     any(Class.class))).willThrow(badRequest);
 
                 // when
-                byte[] image = dalleRequestService.getImageAsUrl("prompt");
-
                 // then
-                assertThat(image).isNull();
+                assertThatThrownBy(() -> dalleRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(DallEPolicyViolationException.class);
             }
 
             @Test

--- a/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
@@ -1,0 +1,126 @@
+package tipitapi.drawmytoday.domain.dalle.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.common.testdata.TestEmotion;
+import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
+import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
+import tipitapi.drawmytoday.domain.diary.service.PromptService;
+import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
+import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
+
+@ExtendWith(MockitoExtension.class)
+class DallEServiceTest {
+
+    @Mock
+    RestTemplate restTemplate;
+    String apiUrl = "openaiDalleUrl";
+    @Mock
+    PromptTextService promptTextService;
+    @Mock
+    PromptService promptService;
+    DallEService dallEService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        dallEService = new DallEService(restTemplate, apiUrl, promptTextService, promptService);
+    }
+
+    @Nested
+    @DisplayName("generateImage 메서드는")
+    class GenerateImage_test {
+
+        @BeforeEach
+        void setUp() {
+            given(promptTextService.createPromptText(any(Emotion.class), any(String.class)))
+                .willReturn("prompt");
+        }
+
+        @Test
+        @DisplayName("dalle 요청을 실패할 경우 fail prompt를 저장한다.")
+        void dalle_request_fail_then_generateImage_fail() {
+            // given
+            Emotion emotion = TestEmotion.createEmotion();
+            String keyword = "keyword";
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willReturn(null);
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
+                .isInstanceOf(DallERequestFailException.class);
+            verify(promptService).createPrompt(any(String.class), eq(false));
+        }
+
+        @Test
+        @DisplayName("dalle 요청시 dalle 정책 위반에 대한 응답이 오면 다시 요청을 보낸다.")
+        void dalle_request_fail_then_generateImage_fail_and_retry() {
+            // given
+            String responsebody = "\n 400 Bad Request: \"{<EOL>  \"error\": {<EOL>    \"code\": \"content_policy_violation\",<EOL>    \"message\": \"Your request was rejected as a result of our safety system. Your prompt may contain text that is not allowed by our safety system.\",<EOL>    \"param\": null,<EOL>    \"type\": \"invalid_request_error\"<EOL>  }<EOL>}<EOL>\"";
+            HttpClientErrorException badRequest = new HttpClientErrorException(
+                HttpStatus.BAD_REQUEST,
+                "bad request",
+                responsebody.getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8);
+            Emotion emotion = TestEmotion.createEmotion();
+            String keyword = "keyword";
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willThrow(badRequest);
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
+                .isInstanceOf(DallERequestFailException.class);
+            verify(promptService).createPrompt(any(String.class), eq(false));
+            verify(promptTextService).createPromptText(eq(emotion), eq(null));
+        }
+
+        @Nested
+        @DisplayName("dalle 요청을 성공할 경우")
+        class Dalle_request_success {
+
+
+            @Test
+            @DisplayName("응답값이 비정상적이면 예외를 던지고 fail prompt를 저장한다.")
+            void invalid_response_then_throw_exception_and_save_prompt() {
+                // given
+                Emotion emotion = TestEmotion.createEmotion();
+                String keyword = "keyword";
+                DallEUrlResponse response = new DallEUrlResponse();
+                ReflectionTestUtils.setField(response, "data", List.of());
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(response);
+
+                // when
+                // then
+                Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
+                    .isInstanceOf(DallERequestFailException.class);
+                verify(promptService).createPrompt(any(String.class), eq(false));
+            }
+
+        }
+
+
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.domain.dalle.dto.GeneratedImageAndPrompt;
+import tipitapi.drawmytoday.domain.dalle.exception.DallEPolicyViolationException;
 import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
@@ -72,15 +73,15 @@ class DallEServiceTest {
                 Emotion emotion = TestEmotion.createEmotion();
                 given(promptTextService.createPromptText(eq(emotion), eq(keyword)))
                     .willReturn(prompt);
-                given(dalleRequestService.getImageAsUrl(eq(prompt))).willReturn(null);
+                given(dalleRequestService.getImageAsUrl(eq(prompt))).willThrow(
+                    DallEPolicyViolationException.class);
                 given(promptTextService.createPromptText(eq(emotion), eq(null)))
                     .willReturn(otherPrompt);
                 given(dalleRequestService.getImageAsUrl(eq(otherPrompt))).willReturn(image);
 
                 // when
                 GeneratedImageAndPrompt generatedImageAndPrompt = dallEService.generateImage(
-                    emotion,
-                    keyword);
+                    emotion, keyword);
 
                 // then
                 verify(promptService).createPrompt(eq(prompt), eq(false));
@@ -98,10 +99,12 @@ class DallEServiceTest {
                 Emotion emotion = TestEmotion.createEmotion();
                 given(promptTextService.createPromptText(eq(emotion), eq(keyword)))
                     .willReturn(prompt);
-                given(dalleRequestService.getImageAsUrl(eq(prompt))).willReturn(null);
+                given(dalleRequestService.getImageAsUrl(eq(prompt))).willThrow(
+                    DallEPolicyViolationException.class);
                 given(promptTextService.createPromptText(eq(emotion), eq(null)))
                     .willReturn(otherPrompt);
-                given(dalleRequestService.getImageAsUrl(eq(otherPrompt))).willReturn(null);
+                given(dalleRequestService.getImageAsUrl(eq(otherPrompt))).willThrow(
+                    DallEPolicyViolationException.class);
 
                 // when
                 // then

--- a/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/dalle/service/DallEServiceTest.java
@@ -1,28 +1,22 @@
 package tipitapi.drawmytoday.domain.dalle.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static tipitapi.drawmytoday.common.exception.ErrorCode.DALLE_CONTENT_POLICY_VIOLATION;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
-import tipitapi.drawmytoday.domain.dalle.dto.DallEUrlResponse;
+import tipitapi.drawmytoday.domain.dalle.dto.GeneratedImageAndPrompt;
 import tipitapi.drawmytoday.domain.dalle.exception.DallERequestFailException;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
@@ -32,95 +26,117 @@ import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 class DallEServiceTest {
 
     @Mock
-    RestTemplate restTemplate;
-    String apiUrl = "openaiDalleUrl";
-    @Mock
     PromptTextService promptTextService;
     @Mock
     PromptService promptService;
+    @Mock
+    DallERequestService dalleRequestService;
+    @InjectMocks
     DallEService dallEService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-
-        dallEService = new DallEService(restTemplate, apiUrl, promptTextService, promptService);
-    }
 
     @Nested
     @DisplayName("generateImage 메서드는")
     class GenerateImage_test {
 
-        @BeforeEach
-        void setUp() {
-            given(promptTextService.createPromptText(any(Emotion.class), any(String.class)))
-                .willReturn("prompt");
-        }
-
         @Test
         @DisplayName("dalle 요청을 실패할 경우 fail prompt를 저장한다.")
-        void dalle_request_fail_then_generateImage_fail() {
+        void dalle_request_fail_then_generateImage_fail() throws Exception {
             // given
             Emotion emotion = TestEmotion.createEmotion();
             String keyword = "keyword";
-            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
-                any(Class.class))).willReturn(null);
+            String prompt = "prompt";
+            given(promptTextService.createPromptText(any(Emotion.class), any(String.class)))
+                .willReturn(prompt);
+            given(dalleRequestService.getImageAsUrl(eq(prompt)))
+                .willThrow(DallERequestFailException.class);
 
             // when
             // then
-            Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
+            assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
                 .isInstanceOf(DallERequestFailException.class);
             verify(promptService).createPrompt(any(String.class), eq(false));
         }
 
-        @Test
-        @DisplayName("dalle 요청시 dalle 정책 위반에 대한 응답이 오면 다시 요청을 보낸다.")
-        void dalle_request_fail_then_generateImage_fail_and_retry() {
-            // given
-            String responsebody = "\n 400 Bad Request: \"{<EOL>  \"error\": {<EOL>    \"code\": \"content_policy_violation\",<EOL>    \"message\": \"Your request was rejected as a result of our safety system. Your prompt may contain text that is not allowed by our safety system.\",<EOL>    \"param\": null,<EOL>    \"type\": \"invalid_request_error\"<EOL>  }<EOL>}<EOL>\"";
-            HttpClientErrorException badRequest = new HttpClientErrorException(
-                HttpStatus.BAD_REQUEST,
-                "bad request",
-                responsebody.getBytes(StandardCharsets.UTF_8),
-                StandardCharsets.UTF_8);
-            Emotion emotion = TestEmotion.createEmotion();
-            String keyword = "keyword";
-            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
-                any(Class.class))).willThrow(badRequest);
+        @Nested
+        @DisplayName("dalle 요청시 dalle 정책 위반에 대한 응답이 오면")
+        class Dalle_request_policy_violation {
 
-            // when
-            // then
-            Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
-                .isInstanceOf(DallERequestFailException.class);
-            verify(promptService).createPrompt(any(String.class), eq(false));
-            verify(promptTextService).createPromptText(eq(emotion), eq(null));
+            @Test
+            @DisplayName("fail prompt 저장 후 다시 요청을 보낸 후 이미지를 반환한다.")
+            void retry_and_return_image() throws Exception {
+                // given
+                String prompt = "prompt";
+                String otherPrompt = "otherPrompt";
+                String keyword = "keyword";
+                byte[] image = new byte[0];
+                Emotion emotion = TestEmotion.createEmotion();
+                given(promptTextService.createPromptText(eq(emotion), eq(keyword)))
+                    .willReturn(prompt);
+                given(dalleRequestService.getImageAsUrl(eq(prompt))).willReturn(null);
+                given(promptTextService.createPromptText(eq(emotion), eq(null)))
+                    .willReturn(otherPrompt);
+                given(dalleRequestService.getImageAsUrl(eq(otherPrompt))).willReturn(image);
+
+                // when
+                GeneratedImageAndPrompt generatedImageAndPrompt = dallEService.generateImage(
+                    emotion,
+                    keyword);
+
+                // then
+                verify(promptService).createPrompt(eq(prompt), eq(false));
+                verify(promptTextService).createPromptText(any(Emotion.class), eq(null));
+                assertThat(generatedImageAndPrompt.getImage()).isEqualTo(image);
+            }
+
+            @Test
+            @DisplayName("fail prompt 저장 후 다시 요청을 보내도 정책 위반 응답이 오면 예외를 던진다.")
+            void retry_but_policy_violation_then_throw_exception() throws Exception {
+                // given
+                String prompt = "prompt";
+                String otherPrompt = "otherPrompt";
+                String keyword = "keyword";
+                Emotion emotion = TestEmotion.createEmotion();
+                given(promptTextService.createPromptText(eq(emotion), eq(keyword)))
+                    .willReturn(prompt);
+                given(dalleRequestService.getImageAsUrl(eq(prompt))).willReturn(null);
+                given(promptTextService.createPromptText(eq(emotion), eq(null)))
+                    .willReturn(otherPrompt);
+                given(dalleRequestService.getImageAsUrl(eq(otherPrompt))).willReturn(null);
+
+                // when
+                // then
+                assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
+                    .isInstanceOf(DallERequestFailException.class)
+                    .hasMessage(DALLE_CONTENT_POLICY_VIOLATION.getMessage());
+                verify(promptService).createPrompt(eq(prompt), eq(false));
+                verify(promptTextService).createPromptText(any(Emotion.class), eq(null));
+                verify(promptService).createPrompt(eq(otherPrompt), eq(false));
+            }
         }
 
         @Nested
         @DisplayName("dalle 요청을 성공할 경우")
         class Dalle_request_success {
 
-
             @Test
-            @DisplayName("응답값이 비정상적이면 예외를 던지고 fail prompt를 저장한다.")
-            void invalid_response_then_throw_exception_and_save_prompt() {
+            @DisplayName("이미지를 반환한다.")
+            void save_prompt_and_return_image() throws Exception {
                 // given
-                Emotion emotion = TestEmotion.createEmotion();
+                String prompt = "prompt";
                 String keyword = "keyword";
-                DallEUrlResponse response = new DallEUrlResponse();
-                ReflectionTestUtils.setField(response, "data", List.of());
-                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
-                    any(Class.class))).willReturn(response);
+                byte[] image = new byte[0];
+                Emotion emotion = TestEmotion.createEmotion();
+                given(promptTextService.createPromptText(any(Emotion.class), any(String.class)))
+                    .willReturn(prompt);
+                given(dalleRequestService.getImageAsUrl(eq(prompt))).willReturn(image);
 
                 // when
+                GeneratedImageAndPrompt generatedImageAndPrompt = dallEService.generateImage(
+                    emotion, keyword);
+
                 // then
-                Assertions.assertThatThrownBy(() -> dallEService.generateImage(emotion, keyword))
-                    .isInstanceOf(DallERequestFailException.class);
-                verify(promptService).createPrompt(any(String.class), eq(false));
+                assertThat(generatedImageAndPrompt.getImage()).isEqualTo(image);
             }
-
         }
-
-
     }
 }


### PR DESCRIPTION
# 구현 내용

**dalle 도메인 서비스단 테스트코드 작성 중 mocking한 클래스의 같은 메서드 동작을 여러 번 정의할 때 파라미터의 값이 다를 때마다 다르게 동작하도록 구현하는 과정에서 복잡도가 많이 증가하는 이슈가 있었습니다. 따라서 dalle rest 요청을 실제로 호출하는 메서드를 다른 클래스로 분리했습니다.**

## 구현 요약

- dalle rest 요청 분리(DallERequestService 추가)
- dalle 도메인 서비스단 테스트코드 추가

## 관련 이슈

close #226 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
