### PR TITLE
유저 그림 평가 기능 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/resolver/AuthUser.java
+++ b/src/main/java/tipitapi/drawmytoday/common/resolver/AuthUser.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.common.resolver;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,6 +8,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface AuthUser {
 
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
@@ -34,6 +34,7 @@ import tipitapi.drawmytoday.domain.diary.dto.GetDiaryLimitResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetLastCreationResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
+import tipitapi.drawmytoday.domain.diary.dto.ReviewDiaryRequest;
 import tipitapi.drawmytoday.domain.diary.dto.UpdateDiaryRequest;
 import tipitapi.drawmytoday.domain.diary.service.CreateDiaryService;
 import tipitapi.drawmytoday.domain.diary.service.DiaryService;
@@ -249,5 +250,29 @@ public class DiaryController {
         return SuccessResponse.of(
             diaryService.getDrawLimit(tokenInfo.getUserId())
         ).asHttp(HttpStatus.OK);
+    }
+
+    @Operation(summary = "일기 평가", description = "주어진 ID의 일기를 평가한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 일기를 평가함"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @PostMapping("/{id}/review")
+    public ResponseEntity<Void> reviewDiary(
+        @AuthUser JwtTokenInfo tokenInfo,
+        @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId,
+        @RequestBody @Valid ReviewDiaryRequest reviewDiaryRequest
+    ) {
+        diaryService.reviewDiary(tokenInfo.getUserId(), diaryId, reviewDiaryRequest.getReview());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
@@ -117,4 +117,8 @@ public class Diary extends BaseEntityWithUpdate {
     public void setNotes(String notes) {
         this.notes = notes;
     }
+
+    public void reviewDiary(ReviewType reviewType) {
+        this.review = reviewType;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/ReviewType.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/ReviewType.java
@@ -1,5 +1,5 @@
 package tipitapi.drawmytoday.domain.diary.domain;
 
 public enum ReviewType {
-    BAD, NORMAL, GOOD
+    BAD, GOOD
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/ReviewDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/ReviewDiaryRequest.java
@@ -1,0 +1,18 @@
+package tipitapi.drawmytoday.domain.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.domain.diary.domain.ReviewType;
+
+@Getter
+@Schema(description = "일기 리뷰 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewDiaryRequest {
+
+    @NotNull
+    @Schema(description = "평가 정보")
+    private ReviewType review;
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -14,6 +14,7 @@ import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.domain.ReviewType;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryExistByDateResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryLimitResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryResponse;
@@ -136,5 +137,13 @@ public class DiaryService {
                     diary.getDiaryDate());
             })
             .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void reviewDiary(Long userId, Long diaryId, ReviewType reviewType) {
+        User user = validateUserService.validateUserById(userId);
+        Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
+
+        diary.reviewDiary(reviewType);
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -35,6 +37,7 @@ import tipitapi.drawmytoday.common.testdata.TestDiary;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.common.testdata.TestUser;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
+import tipitapi.drawmytoday.domain.diary.domain.ReviewType;
 import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryExistByDateResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryLimitResponse;
@@ -454,6 +457,52 @@ class DiaryControllerTest extends ControllerTestSetup {
                     parseLocalDateTime(lastDiaryCreatedDate)))
                 .andExpect(jsonPath("$.data.ticketCreatedAt").value(
                     parseLocalDateTime(validRewardCreatedDate)));
+        }
+    }
+
+    @Nested
+    @DisplayName("reviewDiary 메서드는")
+    class ReviewDiaryTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "INVALID_REVIEW"})
+        @DisplayName("review 값이 없거나 잘못된 값이라면 BAD_REQUEST 상태코드를 응답한다.")
+        void invalid_request_body_then_return_400(String review) throws Exception {
+            // given
+            Long diaryId = 1L;
+
+            // when
+            Map<String, Object> requestMap = new HashMap<>();
+            requestMap.put("review", review);
+            String requestBody = objectMapper.writeValueAsString(requestMap);
+            ResultActions result = mockMvc.perform(post(BASIC_URL + "/" + diaryId + "/review")
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("diaryId에 해당하는 일기를 리뷰한다.")
+        void review_diary() throws Exception {
+            // given
+            Long diaryId = 1L;
+            ReviewType reviewType = ReviewType.GOOD;
+
+            // when
+            Map<String, Object> requestMap = new HashMap<>();
+            requestMap.put("review", reviewType);
+            String requestBody = objectMapper.writeValueAsString(requestMap);
+            ResultActions result = mockMvc.perform(post(BASIC_URL + "/" + diaryId + "/review")
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+            // then
+            result.andExpect(status().isNoContent());
+            verify(diaryService).reviewDiary(diaryId, REQUEST_USER_ID, reviewType);
         }
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
@@ -32,6 +32,7 @@ import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
+import tipitapi.drawmytoday.domain.diary.domain.ReviewType;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryExistByDateResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryLimitResponse;
 import tipitapi.drawmytoday.domain.diary.dto.GetDiaryResponse;
@@ -645,6 +646,25 @@ class DiaryServiceTest {
                 assertThat(response.getLastDiaryCreatedAt()).isEqualTo(lastDiaryDate);
                 assertThat(response.getTicketCreatedAt()).isNull();
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("reviewDiary 메소드 테스트")
+    class ReviewDiaryTest {
+
+        @Test
+        @DisplayName("userId와 diaryId 검증 이후 diary의 review를 input으로 받은 review로 수정한다.")
+        void it_updates_diary_review() {
+            User user = createUserWithId(1L);
+            Diary diary = createDiaryWithId(1L, user, createEmotion());
+            given(validateUserService.validateUserById(1L)).willReturn(user);
+            given(validateDiaryService.validateDiaryById(1L, user))
+                .willReturn(diary);
+
+            diaryService.reviewDiary(1L, 1L, ReviewType.GOOD);
+
+            assertThat(diary.getReview()).isEqualTo(ReviewType.GOOD);
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

[POST] /diary/{id}/review
- diaryId에 해당하는 일기 그림 평가 API 생성
- ReviewType BAD, GOOD로 제한

## 관련 이슈

close #230 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
