### PR TITLE
회원가입시 티켓 1장만 발급되도록 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/ticket/service/TicketService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/ticket/service/TicketService.java
@@ -20,7 +20,7 @@ public class TicketService {
     @Transactional
     public void createTicketByJoin(User user) {
         List<Ticket> tickets = new ArrayList<>();
-        for (int i = 0; i < 7; i++) {
+        for (int i = 0; i < 1; i++) {
             tickets.add(Ticket.of(user, TicketType.JOIN));
         }
         ticketRepository.saveAll(tickets);

--- a/src/test/java/tipitapi/drawmytoday/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/ticket/service/TicketServiceTest.java
@@ -33,8 +33,8 @@ public class TicketServiceTest {
     class CreateTicketByJoinTest {
 
         @Test
-        @DisplayName("7개의 JOIN 타입의 티켓을 등록해야합니다.")
-        void it_creates_7_join_tickets() {
+        @DisplayName("1개의 JOIN 타입의 티켓을 등록해야합니다.")
+        void it_creates_1_join_tickets() {
             User user = createUser();
 
             ticketService.createTicketByJoin(user);
@@ -43,7 +43,7 @@ public class TicketServiceTest {
             verify(ticketRepository, times(1)).saveAll(ticketArgumentCaptor.capture());
 
             List<Ticket> tickets = ticketArgumentCaptor.getValue();
-            assertEquals(tickets.size(), 7);
+            assertEquals(tickets.size(), 1);
             assertThat(tickets).allMatch(ticket -> ticket.getTicketType() == TicketType.JOIN);
         }
     }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

정책 변경에 따라 회원가입시 티켓 1장만 발급되도록 변경해서 main에 바로 업데이트했습니다.
따라서 dev 브랜치에도 추가합니다!

Release 1.1.4 노트에도 추가하겠습니다!

## 관련 이슈

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
