### PR TITLE
r2 이미지 조회시 커스텀 url로 조회하도록 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
@@ -30,7 +30,7 @@ public class AdminDiaryService {
 
     private GetDiaryAdminResponse generatePresignedURL(GetDiaryAdminResponse response) {
         response.updateImageUrl(
-            r2PreSignedService.getPreSignedUrlForShare(response.getImageURL(), imageExpiration));
+            r2PreSignedService.getCustomDomainUrl(response.getImageURL()));
         return response;
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -47,8 +47,8 @@ public class DiaryService {
         Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
         diary.setNotes(encryptor.decrypt(diary.getNotes()));
 
-        String imageUrl = r2PreSignedService.getPreSignedUrlForShare(
-            imageService.getImage(diary).getImageUrl(), 30);
+        String imageUrl = r2PreSignedService.getCustomDomainUrl(
+            imageService.getImage(diary).getImageUrl());
 
         String emotionText = diary.getEmotion().getEmotionText(language);
 
@@ -130,8 +130,8 @@ public class DiaryService {
                 return true;
             })
             .map(diary -> {
-                String imageUrl = r2PreSignedService.getPreSignedUrlForShare(
-                    diary.getImageList().get(0).getImageUrl(), 30);
+                String imageUrl = r2PreSignedService.getCustomDomainUrl(
+                    diary.getImageList().get(0).getImageUrl());
                 return GetMonthlyDiariesResponse.of(diary.getDiaryId(), imageUrl,
                     diary.getDiaryDate());
             })

--- a/src/main/java/tipitapi/drawmytoday/domain/r2/service/R2PreSignedService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/r2/service/R2PreSignedService.java
@@ -41,4 +41,8 @@ public class R2PreSignedService {
             throw new R2FailedException(e);
         }
     }
+
+    public String getCustomDomainUrl(String objectKey) {
+        return "https://choihyeok.site/" + objectKey;
+    }
 }


### PR DESCRIPTION
# 구현 내용

SK 브로드밴드 DNS 서버 문제로 R2 도메인이 아닌 커스텀 도메인으로 이미지 url을 생성하도록 변경했습니다.

커스텀 도메인은 pre-signed url을 발급하지 못하는 것으로 알고 있기에 만료시간 없이 url 자체를 발급하도록 변경했습니다.

이미지 폴더 경로로 이미지 url을 발급하는 책임은 R2 클래스가 맡는게 좋을거 같아 R2PreSignedService에 customDomainUrl을 발급하도록 구현했습니다. 다만, 이름을 R2PreSignedService에서 R2ImageUrlService로 변경하는것도 좋을거 같습니다!

## 구현 요약

- 이미지 조회 API, 월별 이미지 조회 API, admin 전체 이미지 조회 API시 발급됐던 pre-signed url을 custom domain url로 변경

## 관련 이슈

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
