### PR TITLE
이미지 삭제 API 추가 및 일기 조회 API 수정

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/SwaggerConfiguration.java
@@ -118,4 +118,15 @@ public class SwaggerConfiguration {
             .pathsToMatch(paths)
             .build();
     }
+
+    @Bean
+    public GroupedOpenApi imageOpenApi() {
+        String[] paths = {"/image/**"};
+
+        return GroupedOpenApi
+            .builder()
+            .group("일기 이미지 API")
+            .pathsToMatch(paths)
+            .build();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -43,7 +43,9 @@ public enum ErrorCode {
     DIARY_DATE_ALREADY_EXISTS(409, "D004", "이미 일기를 그린 날짜입니다."),
 
     // Image
-    IMAGE_NOT_FOUND(404, "I001", "선택된 이미지를 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(404, "I001", "이미지를 찾을 수 없습니다."),
+    SELECTED_IMAGE_DELETION_DENIED(403, "I002", "대표 이미지는 삭제할 수 없습니다."),
+    DIARY_NEEDS_IMAGE(403, "I003", "일기는 최소 한 장의 이미지가 필요합니다."),
 
     // Emotion
     EMOTION_NOT_FOUND(404, "E001", "감정을 찾을 수 없습니다."),

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
@@ -26,4 +26,38 @@ public class ImageController {
 
     private final ImageService imageService;
 
+    @Operation(summary = "일기 이미지 삭제", description = "주어진 ID의 일기 이미지를 삭제(Soft Delete)한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 일기 이미지를 삭제함"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "D002 : 자신의 일기에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "I002 : 대표 이미지는 삭제할 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "I003 : 일기는 최소 한 장의 이미지가 필요합니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "I001 : 선택된 이미지를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteImage(
+        @AuthUser JwtTokenInfo tokenInfo,
+        @Parameter(description = "일기 이미지 id", in = ParameterIn.PATH) @PathVariable("id") Long imageId
+    ) {
+        imageService.deleteImage(tokenInfo.getUserId(), imageId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
@@ -1,0 +1,29 @@
+package tipitapi.drawmytoday.domain.diary.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.resolver.AuthUser;
+import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
+import tipitapi.drawmytoday.domain.diary.service.ImageService;
+
+@RestController
+@RequestMapping("/image")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Authentication")
+public class ImageController {
+
+    private final ImageService imageService;
+
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Image.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Image.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.diary.domain;
 
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -12,8 +13,10 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import tipitapi.drawmytoday.common.entity.BaseEntity;
 
+@SQLDelete(sql = "UPDATE image SET deleted_at = current_timestamp WHERE image_id = ?")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -34,6 +37,8 @@ public class Image extends BaseEntity {
 
     @NotNull
     private boolean isSelected;
+
+    private LocalDateTime deletedAt;
 
     private Image(Diary diary, String imageUrl, boolean isSelected) {
         this.diary = diary;

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetImageResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetImageResponse.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetImageResponse {
 
+    private Long id;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @Schema(description = "이미지 생성 시각", requiredMode = RequiredMode.REQUIRED)
@@ -29,7 +31,8 @@ public class GetImageResponse {
     @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
     private String url;
 
-    public static GetImageResponse of(LocalDateTime createdAt, boolean selected, String url) {
-        return new GetImageResponse(createdAt, selected, url);
+    public static GetImageResponse of
+        (Long id, LocalDateTime createdAt, boolean selected, String url) {
+        return new GetImageResponse(id, createdAt, selected, url);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/exception/DiaryNeedsImageException.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/exception/DiaryNeedsImageException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.domain.diary.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class DiaryNeedsImageException extends BusinessException {
+
+    public DiaryNeedsImageException() {
+        super(ErrorCode.DIARY_NEEDS_IMAGE);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/exception/SelectedImageDeletionDeniedException.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/exception/SelectedImageDeletionDeniedException.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.domain.diary.exception;
+
+import tipitapi.drawmytoday.common.exception.BusinessException;
+import tipitapi.drawmytoday.common.exception.ErrorCode;
+
+public class SelectedImageDeletionDeniedException extends BusinessException {
+
+    public SelectedImageDeletionDeniedException() {
+        super(ErrorCode.SELECTED_IMAGE_DELETION_DENIED);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
@@ -1,0 +1,11 @@
+package tipitapi.drawmytoday.domain.diary.repository;
+
+import java.util.Optional;
+import tipitapi.drawmytoday.domain.diary.domain.Image;
+
+public interface ImageQueryRepository {
+
+    Optional<Image> findImage(Long imageId);
+
+    Long countImage(Long diaryId);
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
@@ -1,9 +1,12 @@
 package tipitapi.drawmytoday.domain.diary.repository;
 
+import java.util.List;
 import java.util.Optional;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
 
 public interface ImageQueryRepository {
+
+    List<Image> findLatestByDiary(Long diaryId);
 
     Optional<Image> findImage(Long imageId);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -24,7 +24,6 @@ public class ImageQueryRepositoryImpl implements ImageQueryRepository {
 
     @Override
     public Optional<Image> findImage(Long imageId) {
-
         return Optional.ofNullable(
             queryFactory
                 .selectFrom(image)

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.diary.repository;
 import static tipitapi.drawmytoday.domain.diary.domain.QImage.image;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
@@ -11,6 +12,15 @@ import tipitapi.drawmytoday.domain.diary.domain.Image;
 public class ImageQueryRepositoryImpl implements ImageQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Image> findLatestByDiary(Long diaryId) {
+        return queryFactory
+            .selectFrom(image)
+            .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))
+            .orderBy(image.createdAt.desc())
+            .fetch();
+    }
 
     @Override
     public Optional<Image> findImage(Long imageId) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -1,0 +1,33 @@
+package tipitapi.drawmytoday.domain.diary.repository;
+
+import static tipitapi.drawmytoday.domain.diary.domain.QImage.image;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import tipitapi.drawmytoday.domain.diary.domain.Image;
+
+@RequiredArgsConstructor
+public class ImageQueryRepositoryImpl implements ImageQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Image> findImage(Long imageId) {
+
+        return Optional.ofNullable(
+            queryFactory
+                .selectFrom(image)
+                .where(image.imageId.eq(imageId).and(image.deletedAt.isNull()))
+                .fetchFirst());
+    }
+
+    @Override
+    public Long countImage(Long diaryId) {
+        return queryFactory
+            .select(image.count())
+            .from(image)
+            .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))
+            .fetchOne();
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
 
-public interface ImageRepository extends JpaRepository<Image, Long> {
+public interface ImageRepository extends JpaRepository<Image, Long>, ImageQueryRepository {
 
     Optional<Image> findByIsSelectedTrueAndDiary(Diary diary);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
@@ -11,6 +11,4 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageQueryR
     Optional<Image> findByIsSelectedTrueAndDiary(Diary diary);
 
     List<Image> findAllByDiaryDiaryId(Long diaryId);
-
-    List<Image> findAllByDiaryDiaryIdOrderByCreatedAtDesc(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -58,8 +58,9 @@ public class DiaryService {
             .orElseThrow(ImageNotFoundException::new);
 
         List<GetImageResponse> sortedImages = images.stream()
-            .map(image -> GetImageResponse.of(image.getCreatedAt(), image.isSelected(),
-                r2PreSignedService.getCustomDomainUrl(image.getImageUrl())))
+            .map(image ->
+                GetImageResponse.of(image.getImageId(), image.getCreatedAt(), image.isSelected(),
+                    r2PreSignedService.getCustomDomainUrl(image.getImageUrl())))
             .collect(Collectors.toList());
 
         String emotionText = diary.getEmotion().getEmotionText(language);

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -8,9 +8,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
+import tipitapi.drawmytoday.domain.diary.exception.DiaryNeedsImageException;
 import tipitapi.drawmytoday.domain.diary.exception.ImageNotFoundException;
+import tipitapi.drawmytoday.domain.diary.exception.SelectedImageDeletionDeniedException;
 import tipitapi.drawmytoday.domain.diary.repository.ImageRepository;
 import tipitapi.drawmytoday.domain.r2.service.R2Service;
+import tipitapi.drawmytoday.domain.user.domain.User;
+import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
 @Service
 @Transactional(readOnly = true)
@@ -19,6 +23,8 @@ public class ImageService {
 
     private final ImageRepository imageRepository;
     private final R2Service r2Service;
+    private final ValidateUserService validateUserService;
+    private final ValidateDiaryService validateDiaryService;
 
     @Value("${spring.profiles.active:Unknown}")
     private String profile;
@@ -51,5 +57,27 @@ public class ImageService {
     public void unSelectAllImage(Long diaryId) {
         imageRepository.findAllByDiaryDiaryId(diaryId)
             .forEach(image -> image.setSelected(false));
+    }
+
+    @Transactional
+    public void deleteImage(Long userId, Long imageId) {
+        User user = validateUserService.validateUserById(userId);
+        Image image = validateImage(imageId, user);
+
+        imageRepository.delete(image);
+    }
+
+    private Image validateImage(Long imageId, User user) {
+        Image image = imageRepository.findImage(imageId).orElseThrow(ImageNotFoundException::new);
+        if (image.isSelected()) {
+            throw new SelectedImageDeletionDeniedException();
+        }
+
+        validateDiaryService.validateDiaryById(image.getDiary().getDiaryId(), user);
+
+        if (imageRepository.countImage(image.getDiary().getDiaryId()) <= 1) {
+            throw new DiaryNeedsImageException();
+        }
+        return image;
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -39,7 +39,7 @@ public class ImageService {
     }
 
     public List<Image> getLatestImages(Diary diary) {
-        return imageRepository.findAllByDiaryDiaryIdOrderByCreatedAtDesc(diary.getDiaryId());
+        return imageRepository.findLatestByDiary(diary.getDiaryId());
     }
 
     public Image createImage(Diary diary, String imagePath, boolean isSelected) {

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
@@ -85,7 +85,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                     diaryId, LocalDateTime.now(), user, emotion);
                 String imageUrl = "imageUrl";
                 List<GetImageResponse> imageList = List.of(GetImageResponse.of(
-                    LocalDateTime.now(), true, imageUrl));
+                    1L, LocalDateTime.now(), true, imageUrl));
                 String promptText = "promptText";
                 GetDiaryResponse getDiaryResponse = GetDiaryResponse.of(diary, imageUrl,
                     imageList, emotionText, promptText);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
@@ -1,0 +1,31 @@
+package tipitapi.drawmytoday.domain.diary.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.ResultActions;
+import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
+import tipitapi.drawmytoday.common.controller.WithCustomUser;
+import tipitapi.drawmytoday.domain.diary.service.ImageService;
+
+@WebMvcTest(ImageController.class)
+@WithCustomUser
+class ImageControllerTest extends ControllerTestSetup {
+
+    private static final String BASIC_URL = "/image";
+
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockBean
+    private ImageService imageService;
+
+}

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
@@ -28,4 +28,23 @@ class ImageControllerTest extends ControllerTestSetup {
     @MockBean
     private ImageService imageService;
 
+    @Nested
+    @DisplayName("deleteImage 메서드는")
+    class DeleteImageTest {
+
+        @Test
+        @DisplayName("imageId에 해당하는 일기를 삭제한다.")
+        void delete_image() throws Exception {
+            // given
+            Long imageId = 1L;
+
+            // when
+            ResultActions result = mockMvc.perform(delete(BASIC_URL + "/" + imageId)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+            // then
+            result.andExpect(status().isNoContent());
+            verify(imageService).deleteImage(imageId, REQUEST_USER_ID);
+        }
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.domain.diary.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -114,6 +115,27 @@ class ImageRepositoryTest extends BaseRepositoryTest {
                 assertThat(imageRepository.findAllByDiaryDiaryId(diary.getDiaryId()))
                     .isEmpty();
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("findLatestByDiary 메서드 테스트")
+    class FindLatestByDiary {
+
+        @Test
+        @DisplayName("주어진 일기의 최신순 이미지 목록을 반환한다.")
+        void it_returns_latest_images_of_diary() {
+            Diary diary = createDiaryWithId(1L, createUser());
+            Image image1 = createImage(1L, diary);
+            Image image2 = createImage(2L, diary);
+            Image deletedImage = createImage(3L, diary);
+            imageRepository.delete(deletedImage);
+
+            List<Image> result = imageRepository.findLatestByDiary(diary.getDiaryId());
+
+            assertThat(result.size()).isEqualTo(2);
+            assertThat(result.get(0).getImageId()).isEqualTo(image2.getImageId());
+            assertThat(result.get(1).getImageId()).isEqualTo(image1.getImageId());
         }
     }
 

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
@@ -116,4 +116,70 @@ class ImageRepositoryTest extends BaseRepositoryTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("findImage 메소드 테스트")
+    class FindImageTest {
+
+        @Nested
+        @DisplayName("주어진 이미지가 존재할 경우")
+        class if_image_exists {
+
+            @Test
+            @DisplayName("이미지를 반환한다.")
+            void return_image() {
+                Diary diary = createDiaryWithId(1L, createUser());
+                Image image = createImage(1L, diary);
+
+                Optional<Image> foundImage = imageRepository.findImage(image.getImageId());
+
+                assertThat(foundImage.isPresent()).isTrue();
+                assertThat(foundImage.get().getImageId()).isEqualTo(image.getImageId());
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 이미지가 존재하지 않을 경우")
+        class if_image_not_exists {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                assertThat(imageRepository.findImage(1L)).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 이미지가 삭제되었을 경우")
+        class if_image_deleted {
+
+            @Test
+            @DisplayName("null을 반환한다.")
+            void return_null() {
+                Long imageId = 1L;
+                Diary diary = createDiaryWithId(1L, createUser());
+                Image deletedImage = createImage(imageId, diary);
+                imageRepository.delete(deletedImage);
+
+                assertThat(imageRepository.findImage(imageId)).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("countImage 메소드 테스트")
+    class CountImageTest {
+
+        @Test
+        @DisplayName("해당 일기의 이미지 개수를 반환한다.")
+        void return_count_of_images() {
+            Diary diary = createDiaryWithId(1L, createUser());
+            createImage(1L, diary);
+            createImage(2L, diary);
+            imageRepository.delete(createImage(3L, diary));
+
+            assertThat(imageRepository.countImage(diary.getDiaryId())).isEqualTo(2L);
+        }
+
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
@@ -3,12 +3,14 @@ package tipitapi.drawmytoday.domain.diary.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiary;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
 import static tipitapi.drawmytoday.common.testdata.TestEmotion.createEmotion;
+import static tipitapi.drawmytoday.common.testdata.TestImage.createImage;
 import static tipitapi.drawmytoday.common.testdata.TestImage.createImageWithId;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createUser;
 
@@ -20,11 +22,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
+import tipitapi.drawmytoday.domain.diary.exception.DiaryNeedsImageException;
 import tipitapi.drawmytoday.domain.diary.exception.ImageNotFoundException;
+import tipitapi.drawmytoday.domain.diary.exception.SelectedImageDeletionDeniedException;
 import tipitapi.drawmytoday.domain.diary.repository.ImageRepository;
 import tipitapi.drawmytoday.domain.r2.service.R2Service;
+import tipitapi.drawmytoday.domain.user.domain.User;
+import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
@@ -33,6 +40,10 @@ class ImageServiceTest {
     ImageRepository imageRepository;
     @Mock
     R2Service r2Service;
+    @Mock
+    ValidateUserService validateUserService;
+    @Mock
+    ValidateDiaryService validateDiaryService;
     @InjectMocks
     ImageService imageService;
 
@@ -122,6 +133,69 @@ class ImageServiceTest {
             assertThat(createdImage).isEqualTo(image);
             verify(r2Service).uploadImage(any(byte[].class), matches(imagePathRegex));
             verify(imageRepository).save(any(Image.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteImage 메서드는")
+    class DeleteImageTest {
+
+        @Nested
+        @DisplayName("이미지가 존재하지 않으면")
+        class if_image_not_found {
+
+            @Test
+            @DisplayName("ImageNotFoundException 예외를 반환한다.")
+            void it_throws_SelectedImageDeletionException() {
+                User user = createUser();
+
+                given(validateUserService.validateUserById(anyLong())).willReturn(user);
+                given(imageRepository.findImage(anyLong())).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> imageService.deleteImage(1L, 1L))
+                    .isInstanceOf(ImageNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("이미지가 대표 이미지라면")
+        class if_image_is_selected {
+
+            @Test
+            @DisplayName("SelectedImageDeletionException 예외를 반환한다.")
+            void it_throws_SelectedImageDeletionException() {
+                User user = createUser();
+                Diary diary = createDiary(createUser(), createEmotion());
+                Image image = createImage(diary);
+                ReflectionTestUtils.setField(image, "isSelected", true);
+
+                given(validateUserService.validateUserById(anyLong())).willReturn(user);
+                given(imageRepository.findImage(anyLong())).willReturn(Optional.of(image));
+
+                assertThatThrownBy(() -> imageService.deleteImage(1L, 1L))
+                    .isInstanceOf(SelectedImageDeletionDeniedException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("일기의 이미지가 1개 이하라면")
+        class if_image_count_is_less_than_one {
+
+            @Test
+            @DisplayName("DiaryNeedsImageException 예외를 반환한다.")
+            void it_throws_DiaryNeedsImageException() {
+                User user = createUser();
+                Diary diary = createDiaryWithId(1L, createUser(), createEmotion());
+                Image image = createImage(diary);
+                ReflectionTestUtils.setField(image, "isSelected", false);
+
+                given(validateUserService.validateUserById(anyLong())).willReturn(user);
+                given(imageRepository.findImage(anyLong())).willReturn(Optional.of(image));
+                given(imageRepository.countImage(anyLong())).willReturn(1L);
+
+                assertThatThrownBy(() -> imageService.deleteImage(1L, 1L))
+                    .isInstanceOf(DiaryNeedsImageException.class);
+            }
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [DELETE] /image/{id} : 이미지 삭제 API 추가
- 대표 이미지 삭제 요청시 예외 발생 : SelectedImageDeletionDeniedException
- 요청한 이미지의 일기가 1개 이하의 이미지를 갖고 있는 경우 예외 발생 : DiaryNeedsImageException
- SoftDelete로 이미지 삭제 처리
- deleted_at 컬럼 추가 필요
- queryDSL 기반 Image Repository 생성

### [GET] /diary/{id} : 일기 조회 API 수정
- 삭제된 이미지는 이미지 목록에서 제외하는 Repository 메서드 사용
   - 기존에 일기 조회시 이미지 목록을 조회하기 위해 사용한 `findAllByDiaryDiaryIdOrderByCreatedAtDesc` Repository 메서드 삭제
- GetImageResponse 클래스에 이미지 ID 필드 추가
   - 이미지 ID로 삭제 요청을 보낼 수 있어야하므로 이미지 ID 필드가 필요함

### DB 스키마 변경 사항
```sql
ALTER TABLE image ADD deleted_at datetime AFTER created_at;
```

### 기타
deleted_at이 추가됨에 따라, 다른 ImageRepository 메소드도 `deletedAt is null` 쿼리문 추가가 필요합니다.
다만, 같은 PR에서 구현할 경우 PR이 커질 수 있으므로 별도로 작업할 예정입니다 ( 관련 이슈 : #250 )

## 관련 이슈

close #249 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
