### PR TITLE
ImageRepository QueryDSL 적용에 따른 이관

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
@@ -11,4 +11,6 @@ public interface ImageQueryRepository {
     Optional<Image> findImage(Long imageId);
 
     Long countImage(Long diaryId);
+
+    List<Image> findByDiary(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -39,4 +39,12 @@ public class ImageQueryRepositoryImpl implements ImageQueryRepository {
             .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))
             .fetchOne();
     }
+
+    @Override
+    public List<Image> findByDiary(Long diaryId) {
+        return queryFactory
+            .selectFrom(image)
+            .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))
+            .fetch();
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
@@ -1,14 +1,10 @@
 package tipitapi.drawmytoday.domain.diary.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageQueryRepository {
-
-    Optional<Image> findByIsSelectedTrueAndDiary(Diary diary);
 
     List<Image> findAllByDiaryDiaryId(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepository.java
@@ -1,10 +1,8 @@
 package tipitapi.drawmytoday.domain.diary.repository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageQueryRepository {
 
-    List<Image> findAllByDiaryDiaryId(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -46,7 +46,7 @@ public class ImageService {
 
     @Transactional
     public void unSelectAllImage(Long diaryId) {
-        imageRepository.findAllByDiaryDiaryId(diaryId)
+        imageRepository.findByDiary(diaryId)
             .forEach(image -> image.setSelected(false));
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -29,15 +29,6 @@ public class ImageService {
     @Value("${spring.profiles.active:Unknown}")
     private String profile;
 
-    public Image getImage(Diary diary) {
-        return imageRepository.findByIsSelectedTrueAndDiary(diary)
-            .orElseThrow(ImageNotFoundException::new);
-    }
-
-    public List<Image> getImages(Diary diary) {
-        return imageRepository.findAllByDiaryDiaryId(diary.getDiaryId());
-    }
-
     public List<Image> getLatestImages(Diary diary) {
         return imageRepository.findLatestByDiary(diary.getDiaryId());
     }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
@@ -26,9 +26,8 @@ class ImageRepositoryTest extends BaseRepositoryTest {
     ImageRepository imageRepository;
 
     @Nested
-    @Nested
-    @DisplayName("findAllByDiaryDiaryId 메소드 테스트")
-    class FindAllByDiaryDiaryIdTest {
+    @DisplayName("findByDiary 메소드 테스트")
+    class FindByDiaryTest {
 
         @Nested
         @DisplayName("주어진 일기의 이미지가 존재할 경우")
@@ -41,7 +40,7 @@ class ImageRepositoryTest extends BaseRepositoryTest {
                 Image image1 = createImage(1L, diary);
                 Image image2 = createImage(2L, diary);
 
-                assertThat(imageRepository.findAllByDiaryDiaryId(diary.getDiaryId()))
+                assertThat(imageRepository.findByDiary(diary.getDiaryId()))
                     .containsExactlyInAnyOrder(image1, image2);
             }
         }
@@ -55,7 +54,23 @@ class ImageRepositoryTest extends BaseRepositoryTest {
             void return_empty_list() {
                 Diary diary = createDiaryWithId(1L, createUser());
 
-                assertThat(imageRepository.findAllByDiaryDiaryId(diary.getDiaryId()))
+                assertThat(imageRepository.findByDiary(diary.getDiaryId()))
+                    .isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 일기의 이미지가 삭제되었을 경우")
+        class if_images_of_diary_deleted {
+
+            @Test
+            @DisplayName("빈 목록을 반환한다.")
+            void return_empty_list() {
+                Diary diary = createDiaryWithId(1L, createUser());
+                Image image1 = createImage(1L, diary);
+                imageRepository.delete(image1);
+
+                assertThat(imageRepository.findByDiary(diary.getDiaryId()))
                     .isEmpty();
             }
         }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/ImageRepositoryTest.java
@@ -16,7 +16,6 @@ import tipitapi.drawmytoday.common.BaseRepositoryTest;
 import tipitapi.drawmytoday.common.config.QuerydslConfig;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Image;
-import tipitapi.drawmytoday.domain.user.domain.User;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -27,62 +26,6 @@ class ImageRepositoryTest extends BaseRepositoryTest {
     ImageRepository imageRepository;
 
     @Nested
-    @DisplayName("findByIsSelectedTrueAndDiary 메소드 테스트")
-    class findByIsSelectedTrueAndDiaryTest {
-
-        @Nested
-        @DisplayName("주어진 일기의 선택된 이미지가 존재할 경우")
-        class if_selected_image_of_diary_exists {
-
-            @Test
-            @DisplayName("이미지를 반환한다.")
-            void return_image() {
-                Diary diary = createDiaryWithId(1L, createUser());
-                Image image = createImage(1L, diary);
-
-                Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(diary);
-
-                assertThat(foundImage.isPresent()).isTrue();
-                assertThat(foundImage.get().getImageId()).isEqualTo(image.getImageId());
-            }
-        }
-
-        @Nested
-        @DisplayName("주어진 일기의 이미지 중, 선택된 이미지가 존재하지 않을 경우")
-        class if_selected_image_of_diary_not_exists {
-
-            @Test
-            @DisplayName("null을 반환한다.")
-            void return_null() {
-                Diary diary = createDiaryWithId(1L, createUser());
-                createImage(1L, diary).setSelected(false);
-
-                Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(diary);
-
-                assertThat(foundImage).isEmpty();
-            }
-        }
-
-        @Nested
-        @DisplayName("주어진 일기가 존재하지 않는 경우")
-        class if_diary_not_exists {
-
-            @Test
-            @DisplayName("null을 반환한다.")
-            void return_null() {
-                User user = createUser();
-                Diary diary = createDiaryWithId(1L, user);
-                Diary otherDiary = createDiaryWithId(2L, user);
-                createImage(1L, diary);
-
-                Optional<Image> foundImage = imageRepository.findByIsSelectedTrueAndDiary(
-                    otherDiary);
-
-                assertThat(foundImage).isEmpty();
-            }
-        }
-    }
-
     @Nested
     @DisplayName("findAllByDiaryDiaryId 메소드 테스트")
     class FindAllByDiaryDiaryIdTest {

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
@@ -48,47 +48,6 @@ class ImageServiceTest {
     ImageService imageService;
 
     @Nested
-    @DisplayName("getImage 메소드 테스트")
-    class GetImageTest {
-
-        @Nested
-        @DisplayName("주어진 일기의 이미지 중 선택된 이미지가 존재할 경우")
-        class if_selected_image_of_diary_exist {
-
-            @Test
-            @DisplayName("이미지를 반환한다.")
-            void it_returns_image() {
-                Diary diary = createDiary(createUser(), createEmotion());
-                Image image = createImageWithId(1L, diary);
-
-                given(imageRepository.findByIsSelectedTrueAndDiary(diary)).willReturn(
-                    Optional.of(image));
-
-                Image getImage = imageService.getImage(diary);
-
-                assertThat(getImage.getImageId()).isEqualTo(image.getImageId());
-            }
-        }
-
-        @Nested
-        @DisplayName("주어진 일기의 이미지 중 선택된 이미지가 존재하지 않을 경우")
-        class if_selected_image_of_diary_not_exist {
-
-            @Test
-            @DisplayName("ImageNotFoundException 예외를 반환한다.")
-            void it_throws_ImageNotFoundException() {
-                Diary diary = createDiary(createUser(), createEmotion());
-
-                given(imageRepository.findByIsSelectedTrueAndDiary(diary)).willReturn(
-                    Optional.empty());
-
-                assertThatThrownBy(() -> imageService.getImage(diary))
-                    .isInstanceOf(ImageNotFoundException.class);
-            }
-        }
-    }
-
-    @Nested
     @DisplayName("createImage 메서드는")
     class CreateImageTest {
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### 이미지 레포지토리 메서드에 deletedAt = null 반영
- findAllByDiaryDiaryId 메서드는 deletedAt = null 이 반영되어 있지 않아서, queryDSL 기반 메서드 findByDiary를 추가하여 교체함
- ImageQueryRepository, ImageQueryRepositoryImpl에 새로운 메서드를 추가함
- findAllByDiaryDiaryId메서드를 사용하는 unSelectAllImage에 대해 findByDiary를 사용하도록 교체함
- ImageRepositoryTest 반영

### 불필요한 레포지토리 메서드 및 서비스 메서드 삭제
- ImageService의 getImage, getImages 메서드가 사용되지 않아 삭제함
- 이에 따라, getImage가 사용하고 있던 이미지 레포지토리 메서드인 findByIsSelectedTrueAndDiary도 삭제함

## 관련 이슈

close #250 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
