### PR TITLE
대표 이미지 설정 API 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/ImageController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -86,6 +87,33 @@ public class ImageController {
         @RequestBody @Valid ReviewDiaryRequest reviewDiaryRequest
     ) {
         imageService.reviewImage(tokenInfo.getUserId(), imageId, reviewDiaryRequest.getReview());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "대표 이미지 설정", description = "주어진 ID의 이미지를 일기의 대표 이미지로 설정한다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "204",
+            description = "성공적으로 이미지를 평가함"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "I004 : 자신의 이미지에만 접근할 수 있습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "D001 : 일기를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "I001 : 이미지를 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> setSelectedImage(
+        @AuthUser JwtTokenInfo tokenInfo,
+        @Parameter(description = "이미지 ID", in = ParameterIn.PATH) @PathVariable("id") Long imageId
+    ) {
+        imageService.setSelectedImage(tokenInfo.getUserId(), imageId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -68,6 +68,16 @@ public class ImageService {
         image.reviewImage(review);
     }
 
+    @Transactional
+    public void setSelectedImage(Long userId, Long imageId) {
+        User user = validateUserService.validateUserById(userId);
+        Image image = validateImageService.validateImageById(imageId);
+        Diary diary = validateDiaryService.validateDiaryById(image.getDiary().getDiaryId(), user);
+
+        unSelectAllImage(diary.getDiaryId());
+        image.setSelected(true);
+    }
+
     private Image validateImage(Long imageId, User user) {
         Image image = imageRepository.findImage(imageId).orElseThrow(ImageNotFoundException::new);
         if (image.isSelected()) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ValidateImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ValidateImageService.java
@@ -17,7 +17,7 @@ public class ValidateImageService {
     private final ImageRepository imageRepository;
 
     public Image validateImageById(Long imageId) {
-        return imageRepository.findById(imageId).orElseThrow(ImageNotFoundException::new);
+        return imageRepository.findImage(imageId).orElseThrow(ImageNotFoundException::new);
     }
 
     public void validateImageOwner(Long imageId, User user) {

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/ImageControllerTest.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.diary.controller;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -97,6 +98,26 @@ class ImageControllerTest extends ControllerTestSetup {
             // then
             result.andExpect(status().isNoContent());
             verify(imageService).reviewImage(imageId, REQUEST_USER_ID, review);
+        }
+    }
+
+    @Nested
+    @DisplayName("setSelectedImage 메서드는")
+    class SetSelectedImageTest {
+
+        @Test
+        @DisplayName("imageId에 해당하는 일기를 대표 설정한다.")
+        void sets_image_selected() throws Exception {
+            // given
+            Long imageId = 1L;
+
+            // when
+            ResultActions result = mockMvc.perform(put(BASIC_URL + "/" + imageId)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+            // then
+            result.andExpect(status().isNoContent());
+            verify(imageService).setSelectedImage(REQUEST_USER_ID, imageId);
         }
     }
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [PUT] /image/{id} 대표 이미지 설정 API 추가
- 컨트롤러, 컨트롤러 테스트, 서비스, 서비스 테스트 추가

### ValidateImageService의 validateImageById가 호출하는 Repository 메서드 교체
- ValidateImageService.validateImageById 메서드는 imageRepository.findById를 호출했었으나, 이는 삭제된 이미지를 제외하지 않습니다.
- 따라서 imageRepository.findImage 메서드로 교체하였습니다.


## 관련 이슈

close #255 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
