### PR TITLE
[월별 일기 반환 API] 대표 이미지가 반환되지 않는 문제 해결

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
+import tipitapi.drawmytoday.domain.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.user.domain.User;
 
@@ -109,6 +110,13 @@ public class Diary extends BaseEntityWithUpdate {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public Image getSelectedImage() {
+        return imageList.stream()
+            .filter(Image::isSelected)
+            .findFirst()
+            .orElseThrow(ImageNotFoundException::new);
     }
 
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Diary.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import tipitapi.drawmytoday.common.entity.BaseEntityWithUpdate;
-import tipitapi.drawmytoday.domain.diary.exception.ImageNotFoundException;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.user.domain.User;
 
@@ -111,12 +110,5 @@ public class Diary extends BaseEntityWithUpdate {
     public void setNotes(String notes) {
         this.notes = notes;
     }
-
-    public Image getSelectedImage() {
-        return imageList.stream()
-            .filter(Image::isSelected)
-            .findFirst()
-            .orElseThrow(ImageNotFoundException::new);
-    }
-
+    
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetMonthlyDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetMonthlyDiariesResponse.java
@@ -5,28 +5,36 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Schema(description = "월별 일기 목록 Response")
-@AllArgsConstructor
 public class GetMonthlyDiariesResponse {
 
     @Schema(description = "일기 아이디", requiredMode = RequiredMode.REQUIRED)
     private final Long id;
 
     @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
-    private final String imageUrl;
+    @Setter
+    private String imageUrl;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @Schema(description = "일기 날짜", requiredMode = RequiredMode.REQUIRED)
     private final LocalDateTime date;
+
+    @QueryProjection
+    public GetMonthlyDiariesResponse(Long id, String imageUrl, LocalDateTime date) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.date = date;
+    }
 
     public static GetMonthlyDiariesResponse of(Long diaryId, String imageUrl,
         LocalDateTime diaryDate) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
@@ -1,12 +1,15 @@
 package tipitapi.drawmytoday.domain.diary.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
+import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
 
 public interface DiaryQueryRepository {
 
@@ -14,4 +17,7 @@ public interface DiaryQueryRepository {
         Direction direction, Long emotionId);
 
     Optional<Diary> getDiaryExistsByDiaryDate(Long userId, LocalDate diaryDate);
+
+    List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, LocalDateTime startMonth,
+        LocalDateTime endMonth);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -75,12 +75,15 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
     public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, LocalDateTime startMonth,
         LocalDateTime endMonth) {
         return queryFactory.select(
-                new QGetMonthlyDiariesResponse(diary.diaryId, image.imageUrl, diary.diaryDate))
+                new QGetMonthlyDiariesResponse(diary.diaryId, image.imageUrl.max(), diary.diaryDate))
             .from(diary)
             .leftJoin(image)
-            .on(diary.diaryId.eq(image.diary.diaryId).and(image.isSelected.eq(true)))
+            .on(diary.diaryId.eq(image.diary.diaryId)
+                .and(image.isSelected.eq(true)))
             .where(diary.diaryDate.between(startMonth, endMonth)
                 .and(diary.user.userId.eq(userId)))
+            .orderBy(diary.diaryDate.asc())
+            .groupBy(diary.diaryId)
             .fetch();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,8 @@ import org.springframework.data.support.PageableExecutionUtils;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.domain.admin.dto.QGetDiaryAdminResponse;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
+import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
+import tipitapi.drawmytoday.domain.diary.dto.QGetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 
 @RequiredArgsConstructor
@@ -66,5 +69,18 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
             .where(diary.diaryDate.between(diaryDate.atStartOfDay(), diaryDate.atTime(23, 59, 59))
                 .and(diary.user.userId.eq(userId)))
             .fetchFirst());
+    }
+
+    @Override
+    public List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, LocalDateTime startMonth,
+        LocalDateTime endMonth) {
+        return queryFactory.select(
+                new QGetMonthlyDiariesResponse(diary.diaryId, image.imageUrl, diary.diaryDate))
+            .from(diary)
+            .leftJoin(image)
+            .on(diary.diaryId.eq(image.diary.diaryId).and(image.isSelected.eq(true)))
+            .where(diary.diaryDate.between(startMonth, endMonth)
+                .and(diary.user.userId.eq(userId)))
+            .fetch();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -143,7 +143,7 @@ public class DiaryService {
             })
             .map(diary -> {
                 String imageUrl = r2PreSignedService.getCustomDomainUrl(
-                    diary.getImageList().get(0).getImageUrl());
+                    diary.getSelectedImage().getImageUrl());
                 return GetMonthlyDiariesResponse.of(diary.getDiaryId(), imageUrl,
                     diary.getDiaryDate());
             })

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.common.converter.Language;
@@ -29,6 +30,7 @@ import tipitapi.drawmytoday.domain.ticket.service.ValidateTicketService;
 import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -76,9 +78,16 @@ public class DiaryService {
         LocalDateTime endMonth = DateUtils.getEndDate(year, month);
         List<GetMonthlyDiariesResponse> monthlyDiaries = diaryRepository.getMonthlyDiaries(
             userId, startMonth, endMonth);
-        for (GetMonthlyDiariesResponse monthlyDiary : monthlyDiaries) {
-            monthlyDiary.setImageUrl(
-                r2PreSignedService.getCustomDomainUrl(monthlyDiary.getImageUrl()));
+
+        for (int i = 0; i < monthlyDiaries.size(); i++) {
+            GetMonthlyDiariesResponse monthlyDiary = monthlyDiaries.get(i);
+            if (monthlyDiary.getImageUrl() == null) {
+                log.error("DiaryId가 {}에 해당하는 이미지가 없습니다.", monthlyDiary.getId());
+                monthlyDiaries.remove(i--);
+            } else {
+                monthlyDiary.setImageUrl(
+                    r2PreSignedService.getCustomDomainUrl(monthlyDiary.getImageUrl()));
+            }
         }
         return monthlyDiaries;
     }


### PR DESCRIPTION
# 구현 내용

Before: 월별 일기 반환 API에서 각 일기별로 반환되는 imageUrl은 가장 옛날에 그린 이미지의 imageUrl 한 개
After: 월별 일기 반환 API에서 각 일기별로 반환되는 imageUrl은 일기의 대표 이미지의 imageUrl 한 개

- diaryId에 해당하는 대표 이미지가 없다면?
1. 에러 로그를 남긴다.
2. 리스트에서 해당 일기를 제외하여 반환한다.

- 만약 diaryId에 해당하는 대표 이미지가 여러 개라면?
가장 최근에 생성한 이미지를 반환한다.

## 구현 요약

- queryDSL + DTO projection으로 월별 일기 목록 조회하도록 변경
- 실패하는 테스트 수정

## 관련 이슈

close #252

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
