### PR TITLE
[관리자 일기 목록 API] 이미지 평가, 이미지 생성 시간 필드 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryAdminResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryAdminResponse.java
@@ -27,16 +27,26 @@ public class GetDiaryAdminResponse {
     @Schema(description = "일기 작성 시간", requiredMode = RequiredMode.REQUIRED)
     private final LocalDateTime createdAt;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @Schema(description = "이미지 생성 시간", requiredMode = RequiredMode.REQUIRED)
+    private final LocalDateTime imageCreatedAt;
+
     @Schema(description = "일기 이미지 URL", requiredMode = RequiredMode.NOT_REQUIRED)
     private String imageURL;
 
+    @Schema(description = "평가 점수 (1~5 사이의 숫자)")
+    private final String review;
+
     @QueryProjection
     public GetDiaryAdminResponse(Long id, String imageURL, String prompt,
-        LocalDateTime createdAt) {
+        LocalDateTime createdAt, LocalDateTime imageCreatedAt, String review) {
         this.id = id;
         this.imageURL = imageURL;
         this.prompt = prompt;
         this.createdAt = createdAt;
+        this.imageCreatedAt = imageCreatedAt;
+        this.review = review;
     }
 
     public void updateImageUrl(String imageUrl) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -43,12 +43,12 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
 
         List<GetDiaryAdminResponse> content = queryFactory.select(
                 new QGetDiaryAdminResponse(diary.diaryId, image.imageUrl, prompt.promptText,
-                    diary.createdAt))
+                    diary.createdAt, image.createdAt, image.review))
             .from(diary)
             .leftJoin(image).on(diary.diaryId.eq(image.diary.diaryId))
             .leftJoin(prompt).on(diary.diaryId.eq(prompt.diary.diaryId))
             .where(withoutTest, withEmotion)
-            .orderBy(direction.isAscending() ? diary.createdAt.asc() : diary.createdAt.desc())
+            .orderBy(direction.isAscending() ? image.createdAt.asc() : image.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
@@ -53,11 +53,11 @@ class AdminControllerTest extends ControllerTestSetup {
             diaries.add(new GetDiaryAdminResponse(1L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                 "happy , pink , canvas-textured, Oil Pastel, a crowded subway",
-                LocalDateTime.now().minusDays(5)));
+                LocalDateTime.now().minusDays(5), LocalDateTime.now(), null));
             diaries.add(new GetDiaryAdminResponse(2L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                 "angry , blue , glass-textured, crayon, school",
-                LocalDateTime.now().minusDays(1)));
+                LocalDateTime.now().minusDays(1), LocalDateTime.now(), "3"));
             given(adminService.getDiaries(anyLong(), anyInt(), anyInt(), any(Direction.class),
                 anyLong()))
                 .willReturn(new PageImpl<>(diaries, pageable, 2));

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
@@ -73,11 +73,11 @@ class AdminServiceTest {
                 diaries.add(new GetDiaryAdminResponse(1L,
                     "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                     "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
-                    LocalDateTime.of(2023, 6, 16, 15, 0, 0)));
+                    LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4"));
                 diaries.add(new GetDiaryAdminResponse(2L,
                     "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                     "angry , purple , canvas-textured, Oil Pastel, school",
-                    LocalDateTime.of(2023, 6, 17, 15, 0, 0)));
+                    LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), "3"));
                 given(adminDiaryService.getDiaries(any(Integer.class), any(Integer.class),
                     any(Direction.class), anyLong())).willReturn(new PageImpl<>(diaries));
 

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
@@ -45,11 +45,11 @@ class AdminDiaryServiceTest {
             diaries.add(new GetDiaryAdminResponse(1L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                 "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
-                LocalDateTime.of(2023, 6, 16, 15, 0, 0)));
+                LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4"));
             diaries.add(new GetDiaryAdminResponse(2L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                 "angry , purple , canvas-textured, Oil Pastel, school",
-                LocalDateTime.of(2023, 6, 17, 15, 0, 0)));
+                LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), null));
             given(
                 diaryRepository.getDiariesForMonitorAsPage(any(Pageable.class),
                     any(Direction.class), eq(1L)))


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [GET] /admin/diaries 관리자 일기 목록 조회 API : 이미지 평가, 이미지 생성 시간 필드 추가
- GetAdminDiaryResponse 에 이미지 평가 review, 이미지 생성 시간 imageCreatedAt 필드 추가
- 이미지를 기준으로 리턴해야했는데, 이미지 Left Outer Join이 적용되어 있어 하나의 일기당 여러개의 이미지 컬럼을 작업할 수 있는 구조임
- 또한, 이미지를 기준으로 리턴해야하지만, 감정 필터링이나 프롬프트 매칭 때문에 Diary를 기준으로 이미지를 조회해야만 함

## 관련 이슈

close #254 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
