### PR TITLE
[월별 일기 목록 API] 대표 이미지가 없을 경우 분기 처리 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetMonthlyDiariesResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/GetMonthlyDiariesResponse.java
@@ -19,7 +19,7 @@ public class GetMonthlyDiariesResponse {
     @Schema(description = "일기 아이디", requiredMode = RequiredMode.REQUIRED)
     private final Long id;
 
-    @Schema(description = "이미지 URL", requiredMode = RequiredMode.REQUIRED)
+    @Schema(description = "대표 이미지 URL", requiredMode = RequiredMode.REQUIRED)
     @Setter
     private String imageUrl;
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
@@ -17,4 +17,5 @@ public interface ImageQueryRepository {
 
     Optional<Image> findByImageIdAndDiaryUser(Long imageId, User user);
 
+    Optional<Image> findOneLastedByDiary(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepository.java
@@ -17,5 +17,5 @@ public interface ImageQueryRepository {
 
     Optional<Image> findByImageIdAndDiaryUser(Long imageId, User user);
 
-    Optional<Image> findOneLastedByDiary(Long diaryId);
+    Optional<Image> findRecentByDiary(Long diaryId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -58,4 +58,13 @@ public class ImageQueryRepositoryImpl implements ImageQueryRepository {
                 .and(image.deletedAt.isNull()))
             .fetchFirst());
     }
+
+    @Override
+    public Optional<Image> findOneLastedByDiary(Long diaryId) {
+        return Optional.ofNullable(queryFactory
+            .selectFrom(image)
+            .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))
+            .orderBy(image.createdAt.desc())
+            .fetchFirst());
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/ImageQueryRepositoryImpl.java
@@ -60,7 +60,7 @@ public class ImageQueryRepositoryImpl implements ImageQueryRepository {
     }
 
     @Override
-    public Optional<Image> findOneLastedByDiary(Long diaryId) {
+    public Optional<Image> findRecentByDiary(Long diaryId) {
         return Optional.ofNullable(queryFactory
             .selectFrom(image)
             .where(image.diary.diaryId.eq(diaryId).and(image.deletedAt.isNull()))

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -80,23 +80,8 @@ public class DiaryService {
         List<GetMonthlyDiariesResponse> monthlyDiaries = diaryRepository.getMonthlyDiaries(
             userId, startMonth, endMonth);
 
-        for (int i = 0; i < monthlyDiaries.size(); i++) {
-            GetMonthlyDiariesResponse diaryResponse = monthlyDiaries.get(i);
-            if (diaryResponse.getImageUrl() == null) {
-                log.error("DiaryId가 {}인 일기에 해당하는 대표 이미지가 없습니다.", diaryResponse.getId());
-                Optional<Image> latestImage = imageService.getOneLatestImage(diaryResponse.getId());
-                if (latestImage.isPresent()) {
-                    latestImage.get().setSelected(true);
-                    diaryResponse.setImageUrl(
-                        r2PreSignedService.getCustomDomainUrl(latestImage.get().getImageUrl()));
-                } else {
-                    monthlyDiaries.remove(i--);
-                }
-            } else {
-                diaryResponse.setImageUrl(
-                    r2PreSignedService.getCustomDomainUrl(diaryResponse.getImageUrl()));
-            }
-        }
+        validateImageAndConvertUrl(monthlyDiaries);
+
         return monthlyDiaries;
     }
 
@@ -152,5 +137,25 @@ public class DiaryService {
         }
 
         return GetDiaryLimitResponse.of(available, lastDiaryDate, ticketCreatedAt);
+    }
+
+    private void validateImageAndConvertUrl(List<GetMonthlyDiariesResponse> monthlyDiaries) {
+        for (int i = 0; i < monthlyDiaries.size(); i++) {
+            GetMonthlyDiariesResponse diaryResponse = monthlyDiaries.get(i);
+            if (diaryResponse.getImageUrl() == null) {
+                log.error("DiaryId가 {}인 일기에 해당하는 대표 이미지가 없습니다.", diaryResponse.getId());
+                Optional<Image> latestImage = imageService.getOneLatestImage(diaryResponse.getId());
+                if (latestImage.isPresent()) {
+                    latestImage.get().setSelected(true);
+                    diaryResponse.setImageUrl(
+                        r2PreSignedService.getCustomDomainUrl(latestImage.get().getImageUrl()));
+                } else {
+                    monthlyDiaries.remove(i--);
+                }
+            } else {
+                diaryResponse.setImageUrl(
+                    r2PreSignedService.getCustomDomainUrl(diaryResponse.getImageUrl()));
+            }
+        }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -80,7 +80,7 @@ public class DiaryService {
         List<GetMonthlyDiariesResponse> monthlyDiaries = diaryRepository.getMonthlyDiaries(
             userId, startMonth, endMonth);
 
-        validateImageAndConvertUrl(monthlyDiaries);
+        validateSelectedImageAndConvertUrl(monthlyDiaries);
 
         return monthlyDiaries;
     }
@@ -139,7 +139,8 @@ public class DiaryService {
         return GetDiaryLimitResponse.of(available, lastDiaryDate, ticketCreatedAt);
     }
 
-    private void validateImageAndConvertUrl(List<GetMonthlyDiariesResponse> monthlyDiaries) {
+    private void validateSelectedImageAndConvertUrl(
+        List<GetMonthlyDiariesResponse> monthlyDiaries) {
         for (int i = 0; i < monthlyDiaries.size(); i++) {
             GetMonthlyDiariesResponse diaryResponse = monthlyDiaries.get(i);
             if (diaryResponse.getImageUrl() == null) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -36,7 +36,7 @@ public class ImageService {
     }
 
     public Optional<Image> getOneLatestImage(Long diaryId) {
-        return imageRepository.findOneLastedByDiary(diaryId);
+        return imageRepository.findRecentByDiary(diaryId);
     }
 
     public Image createImage(Diary diary, String imagePath, boolean isSelected) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ImageService.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.domain.diary.service;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,10 @@ public class ImageService {
 
     public List<Image> getLatestImages(Diary diary) {
         return imageRepository.findLatestByDiary(diary.getDiaryId());
+    }
+
+    public Optional<Image> getOneLatestImage(Long diaryId) {
+        return imageRepository.findOneLastedByDiary(diaryId);
     }
 
     public Image createImage(Diary diary, String imagePath, boolean isSelected) {

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithId;
 import static tipitapi.drawmytoday.common.testdata.TestDiary.createDiaryWithIdAndCreatedAt;
@@ -237,25 +238,62 @@ class DiaryServiceTest {
         @DisplayName("주어진 유저의 일기가 존재할 경우")
         class if_diary_of_user_exists {
 
-            @Test
-            @DisplayName("일기에 해당하는 이미지가 없을 경우 해당 일기는 반환하지 않는다.")
-            void it_returns_diaries_without_image() {
-                // given
-                User user = createUserWithId(1L);
-                GetMonthlyDiariesResponse response = new GetMonthlyDiariesResponse(
-                    1L, null, LocalDateTime.of(2023, 6, 1, 0, 0));
-                List<GetMonthlyDiariesResponse> responses = new ArrayList<>();
-                responses.add(response);
-                given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(diaryRepository.getMonthlyDiaries(any(Long.class), any(LocalDateTime.class),
-                    any(LocalDateTime.class))).willReturn(responses);
+            @Nested
+            @DisplayName("일기에 해당하는 대표 이미지가 없을 경우")
+            class If_selected_image_not_exist {
 
-                // when
-                List<GetMonthlyDiariesResponse> monthlyDiaries = diaryService.getMonthlyDiaries(
-                    1L, 2023, 6);
+                @Test
+                @DisplayName("가장 최신 이미지를 대표 이미지로 설정한 이후 해당 일기를 포함한 전체 일기를 반환한다.")
+                void change_latest_image_to_selected_image_then_return() {
+                    // given
+                    User user = createUserWithId(1L);
+                    Long diaryId = 2L;
+                    Diary diary = createDiaryWithId(diaryId, user, createEmotion());
+                    Image latestImage = createImage(diary);
+                    latestImage.setSelected(false);
+                    GetMonthlyDiariesResponse response = new GetMonthlyDiariesResponse(
+                        diaryId, null, LocalDateTime.of(2023, 6, 1, 0, 0));
+                    List<GetMonthlyDiariesResponse> responses = new ArrayList<>();
+                    responses.add(response);
 
-                // then
-                assertThat(monthlyDiaries).hasSize(0);
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(diaryRepository.getMonthlyDiaries(any(Long.class),
+                        any(LocalDateTime.class), any(LocalDateTime.class)))
+                        .willReturn(responses);
+                    given(imageService.getOneLatestImage(eq(diaryId)))
+                        .willReturn(Optional.of(latestImage));
+
+                    // when
+                    List<GetMonthlyDiariesResponse> monthlyDiaries = diaryService.getMonthlyDiaries(
+                        1L, 2023, 6);
+
+                    // then
+                    assertThat(monthlyDiaries).hasSize(1);
+                    assertThat(latestImage.isSelected()).isTrue();
+                }
+
+                @Test
+                @DisplayName("가장 최신 이미지도 없을 경우 전체 일기 중 해당 일기는 반환하지 않는다.")
+                void If_latest_image_not_exist_then_return_diaries_without_image() {
+                    // given
+                    User user = createUserWithId(1L);
+                    Long diaryId = 2L;
+                    GetMonthlyDiariesResponse response = new GetMonthlyDiariesResponse(
+                        diaryId, null, LocalDateTime.of(2023, 6, 1, 0, 0));
+                    List<GetMonthlyDiariesResponse> responses = new ArrayList<>();
+                    responses.add(response);
+                    given(validateUserService.validateUserById(1L)).willReturn(user);
+                    given(diaryRepository.getMonthlyDiaries(any(Long.class),
+                        any(LocalDateTime.class), any(LocalDateTime.class))).willReturn(responses);
+                    given(imageService.getOneLatestImage(eq(diaryId))).willReturn(Optional.empty());
+
+                    // when
+                    List<GetMonthlyDiariesResponse> monthlyDiaries = diaryService.getMonthlyDiaries(
+                        1L, 2023, 6);
+
+                    // then
+                    assertThat(monthlyDiaries).hasSize(0);
+                }
             }
 
             @Test
@@ -272,8 +310,7 @@ class DiaryServiceTest {
                     any(LocalDateTime.class))).willReturn(responses);
 
                 List<GetMonthlyDiariesResponse> getDiaryResponses = diaryService.getMonthlyDiaries(
-                    1L,
-                    2023, 6);
+                    1L, 2023, 6);
 
                 assertThat(getDiaryResponses).hasSize(1);
                 assertThat(getDiaryResponses.get(0).getId()).isEqualTo(diaryId);


### PR DESCRIPTION
# 구현 내용

## 구현 요약

**월별 일기 목록 조회시 대표 이미지가 없을 경우 로직 구현**

1. 월별 일기 목록 조회 API 호출 
(이후 검증 및 한 달 간의 일기 조회 로직 동작)
2. 한 달 간의 일기들을 순회하면서 대표 이미지 조회

3. (순회 중) 대표 이미지가 없을 경우 가장 최신 이미지 조회

4-1. (이미지가 있을 경우) 해당 이미지를 대표 이미지로 설정
4-2. (이미지가 없을 경우) 해당 일기는 월별 일기 목록에서 제외 (종료)

5. 대표 이미지로 설정한 이미지 반환

6. 한 달 간의 일기들 반환

- 실패하는 테스트 수정 및 구현한 로직 테스트코드 추가

## 관련 이슈

close #258 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
