### PR TITLE
테스트 일기 생성 API 구현

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
@@ -169,23 +169,13 @@ public class DiaryController {
     @PostMapping()
     public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createDiary(
         @RequestBody @Valid CreateDiaryRequest createDiaryRequest,
-        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
-        @Parameter(description = "테스트 여부", in = ParameterIn.QUERY)
-        @RequestParam(value = "test", required = false, defaultValue = "false") boolean test
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) throws ImageGeneratorException {
-        CreateDiaryResponse response;
-        if (test) {
-            response = createDiaryService.createTestDiary(tokenInfo.getUserId(),
-                createDiaryRequest.getEmotionId(),
-                createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate(), createDiaryRequest.getUserTime());
-        } else {
-            response = createDiaryService.createDiary(tokenInfo.getUserId(),
-                createDiaryRequest.getEmotionId(),
-                createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
-                createDiaryRequest.getDiaryDate(), createDiaryRequest.getUserTime());
-        }
-        return SuccessResponse.of(response).asHttp(HttpStatus.CREATED);
+        return SuccessResponse.of(createDiaryService.createDiary(tokenInfo.getUserId(),
+            createDiaryRequest.getEmotionId(),
+            createDiaryRequest.getKeyword(), createDiaryRequest.getNotes(),
+            createDiaryRequest.getDiaryDate(), createDiaryRequest.getUserTime())
+        ).asHttp(HttpStatus.CREATED);
     }
 
     @Operation(summary = "일기 수정", description = "주어진 일기의 내용을 수정한다.")

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,17 +17,21 @@ import org.springframework.web.bind.annotation.RestController;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
-import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryRequest;
 import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.service.CreateDiaryService;
+import tipitapi.drawmytoday.domain.generator.exception.ImageGeneratorException;
 
 @Profile("!prod")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/diary")
 @SecurityRequirement(name = "Bearer Authentication")
 public class TestDiaryController {
 
+    private final CreateDiaryService createDiaryService;
 
-    @Operation(summary = "테스트 일기 생성", description = "테스트 일기를 생성합니다.")
+    @Operation(summary = "테스트 일기 생성", description = "테스트 일기를 생성합니다.(티켓 소모 x)")
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "200",
@@ -33,9 +39,11 @@ public class TestDiaryController {
     })
     @PostMapping("/test")
     public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createTestDiary(
-        @RequestBody @Valid CreateDiaryRequest createDiaryRequest,
-        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo) {
-        return null;
+        @RequestBody @Valid CreateTestDiaryRequest createTestDiaryRequest,
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo) throws ImageGeneratorException {
+        return SuccessResponse.of(createDiaryService.createTestDiary(
+            tokenInfo.getUserId(), createTestDiaryRequest
+        )).asHttp(HttpStatus.OK);
     }
 
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
@@ -2,6 +2,8 @@ package tipitapi.drawmytoday.domain.diary.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -34,8 +36,25 @@ public class TestDiaryController {
     @Operation(summary = "테스트 일기 생성", description = "테스트 일기를 생성합니다.(티켓 소모 x)")
     @ApiResponses(value = {
         @ApiResponse(
-            responseCode = "200",
-            description = "테스트 일기 생성 성공")
+            responseCode = "201",
+            description = "테스트 일기 생성 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "U004 : 이미 그림일기를 그린 유저입니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "E001 : 감정을 찾을 수 없습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "409",
+            description = "D001 : 이미 일기를 그린 날짜입니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "500",
+            description = "DE001 : DALL-E 이미지 생성에 실패하였습니다. \r\n "
+                + "IIS001 : 이미지 스트림을 가져오는데 실패하였습니다.",
+            content = @Content(schema = @Schema(hidden = true))),
     })
     @PostMapping("/test")
     public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createTestDiary(
@@ -43,7 +62,7 @@ public class TestDiaryController {
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo) throws ImageGeneratorException {
         return SuccessResponse.of(createDiaryService.createTestDiary(
             tokenInfo.getUserId(), createTestDiaryRequest
-        )).asHttp(HttpStatus.OK);
+        )).asHttp(HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryController.java
@@ -1,0 +1,41 @@
+package tipitapi.drawmytoday.domain.diary.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import javax.validation.Valid;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tipitapi.drawmytoday.common.resolver.AuthUser;
+import tipitapi.drawmytoday.common.response.SuccessResponse;
+import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
+import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
+
+@Profile("!prod")
+@RestController
+@RequestMapping("/diary")
+@SecurityRequirement(name = "Bearer Authentication")
+public class TestDiaryController {
+
+
+    @Operation(summary = "테스트 일기 생성", description = "테스트 일기를 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "테스트 일기 생성 성공")
+    })
+    @PostMapping("/test")
+    public ResponseEntity<SuccessResponse<CreateDiaryResponse>> createTestDiary(
+        @RequestBody @Valid CreateDiaryRequest createDiaryRequest,
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo) {
+        return null;
+    }
+
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
@@ -1,0 +1,51 @@
+package tipitapi.drawmytoday.domain.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tipitapi.drawmytoday.common.validator.ValidDiaryDate;
+
+@Getter
+@Schema(description = "태스트 일기 생성 Request")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateTestDiaryRequest {
+
+    @NotNull
+    @Schema(description = "감정 ID")
+    private Long emotionId;
+
+    @Schema(description = "일기 키워드", nullable = true)
+    private String keyword;
+
+    @Size(max = 6010)
+    @Schema(description = "일기 내용", nullable = true)
+    private String notes;
+
+    @NotNull
+    @ValidDiaryDate
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @Schema(description = "일기 날짜")
+    private LocalDate diaryDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    @JsonDeserialize(using = LocalTimeDeserializer.class)
+    @Schema(description = "현재 유저 시간", nullable = true, example = "12:00:00")
+    private LocalTime userTime;
+
+    public LocalTime getUserTime() {
+        if (userTime == null) {
+            return LocalTime.now();
+        }
+        return userTime;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
@@ -40,19 +42,22 @@ public class CreateTestDiaryRequest {
     @Schema(description = "현재 유저 시간", nullable = true, example = "12:00:00")
     private LocalTime userTime;
 
+    @Valid
     private KarloParameter karloParameter;
 
     @Getter
     public static class KarloParameter {
 
-        @Schema(description = "프롬프트", nullable = true)
+        @NotBlank
+        @Schema(description = "프롬프트", nullable = false)
         private String prompt;
 
         @Schema(description = "부정 프롬프트", nullable = true)
         private String negativePrompt;
 
         @Positive
-        @Schema(description = "이미지 개수", nullable = false)
+        @NotNull
+        @Schema(description = "이미지 개수. (양수여야 한다)", nullable = false)
         private Integer samples;
 
         @Schema(description = "이미지 생성 과정의 노이즈 제거 단계 수 (기본값: 25, 최소: 10, 최대 100)",

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,9 +23,6 @@ public class CreateTestDiaryRequest {
     @NotNull
     @Schema(description = "감정 ID")
     private Long emotionId;
-
-    @Schema(description = "일기 키워드", nullable = true)
-    private String keyword;
 
     @Size(max = 6010)
     @Schema(description = "일기 내용", nullable = true)
@@ -41,6 +39,30 @@ public class CreateTestDiaryRequest {
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     @Schema(description = "현재 유저 시간", nullable = true, example = "12:00:00")
     private LocalTime userTime;
+
+    private KarloParameter karloParameter;
+
+    @Getter
+    public static class KarloParameter {
+
+        @Schema(description = "프롬프트", nullable = true)
+        private String prompt;
+
+        @Schema(description = "부정 프롬프트", nullable = true)
+        private String negativePrompt;
+
+        @Positive
+        @Schema(description = "이미지 개수", nullable = false)
+        private Integer samples;
+
+        @Schema(description = "이미지 생성 과정의 노이즈 제거 단계 수 (기본값: 25, 최소: 10, 최대 100)",
+            nullable = true)
+        private Integer priorNumInferenceSteps;
+
+        @Schema(description = "이미지 생성 과정의 노이즈 제거 척도 (기본값: 5.0, 최소: 1.0, 최대: 20.0)",
+            nullable = true)
+        private Double priorGuidanceScale;
+    }
 
     public LocalTime getUserTime() {
         if (userTime == null) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
@@ -62,6 +62,10 @@ public class CreateTestDiaryRequest {
         @Schema(description = "이미지 생성 과정의 노이즈 제거 척도 (기본값: 5.0, 최소: 1.0, 최대: 20.0)",
             nullable = true)
         private Double priorGuidanceScale;
+
+        @Schema(description = "각 이미지 생성 작업에 사용할 시드(Seed) 값. "
+            + "생성할 이미지 수와 같은 길이의 배열이어야 함. 0 이상 4,294,967,295 이하 숫자로 구성", nullable = true)
+        private Long[] seed;
     }
 
     public LocalTime getUserTime() {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.diary.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,11 +68,13 @@ public class CreateDiaryService {
         Emotion emotion = validateEmotionService.validateEmotionById(request.getEmotionId());
         LocalDateTime diaryDateTime = diaryDate.atTime(request.getUserTime());
 
-        byte[] image = karloService.generateTestImage(request);
+        List<byte[]> images = karloService.generateTestImage(request);
 
         Diary diary = saveDiary(request.getNotes(), user, emotion, diaryDateTime, true);
         promptService.createPrompt(diary, request.getKarloParameter().getPrompt(), true);
-        imageService.uploadAndCreateImage(diary, image, true);
+        for (int i = 0; i < images.size(); i++) {
+            imageService.uploadAndCreateImage(diary, images.get(i), i == 0);
+        }
 
         return new CreateDiaryResponse(diary.getDiaryId());
     }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/dalle/service/DallEService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/dalle/service/DallEService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
@@ -62,5 +63,10 @@ public class DallEService implements ImageGeneratorService {
             throw (e instanceof DallEPolicyViolationException) ?
                 DallERequestFailException.violatePolicy() : e;
         }
+    }
+
+    @Override
+    public byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/dalle/service/DallEService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/dalle/service/DallEService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.generator.domain.dalle.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,7 +67,8 @@ public class DallEService implements ImageGeneratorService {
     }
 
     @Override
-    public byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException {
+    public List<byte[]> generateTestImage(CreateTestDiaryRequest request)
+        throws ImageGeneratorException {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
@@ -49,7 +49,7 @@ public class CreateKarloImageRequest {
             .build();
     }
 
-    public static CreateKarloImageRequest test(KarloParameter param) {
+    public static CreateKarloImageRequest createTestRequest(KarloParameter param) {
         return CreateKarloImageRequest.builder()
             .prompt(param.getPrompt())
             .negativePrompt(param.getNegativePrompt())

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
@@ -24,11 +24,12 @@ public class CreateKarloImageRequest {
     private final String returnType;
     private final Integer priorNumInferenceSteps;
     private final Double priorGuidanceScale;
+    private final Long[] seed;
 
     @Builder
     public CreateKarloImageRequest(String prompt, String negativePrompt, String imageFormat,
         Integer samples, String returnType, Integer priorNumInferenceSteps,
-        Double priorGuidanceScale) {
+        Double priorGuidanceScale, Long[] seed) {
         this.prompt = prompt;
         this.negativePrompt = negativePrompt;
         this.imageFormat = imageFormat;
@@ -36,6 +37,7 @@ public class CreateKarloImageRequest {
         this.returnType = returnType;
         this.priorNumInferenceSteps = priorNumInferenceSteps;
         this.priorGuidanceScale = priorGuidanceScale;
+        this.seed = seed;
     }
 
     public static CreateKarloImageRequest withUrl(String prompt) {
@@ -56,6 +58,7 @@ public class CreateKarloImageRequest {
             .returnType("url")
             .priorNumInferenceSteps(param.getPriorNumInferenceSteps())
             .priorGuidanceScale(param.getPriorGuidanceScale())
+            .seed(param.getSeed())
             .build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
@@ -3,8 +3,9 @@ package tipitapi.drawmytoday.domain.generator.domain.karlo.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
 
 /**
  * Request Body 정보:
@@ -12,18 +13,49 @@ import lombok.Getter;
  */
 
 @Getter
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateKarloImageRequest {
 
-    private String prompt;
-    private String negativePrompt;
-    private String imageFormat;
-    private Integer samples;
-    private String returnType;
+    private final String prompt;
+    private final String negativePrompt;
+    private final String imageFormat;
+    private final Integer samples;
+    private final String returnType;
+    private final Integer priorNumInferenceSteps;
+    private final Double priorGuidanceScale;
+
+    @Builder
+    public CreateKarloImageRequest(String prompt, String negativePrompt, String imageFormat,
+        Integer samples, String returnType, Integer priorNumInferenceSteps,
+        Double priorGuidanceScale) {
+        this.prompt = prompt;
+        this.negativePrompt = negativePrompt;
+        this.imageFormat = imageFormat;
+        this.samples = samples;
+        this.returnType = returnType;
+        this.priorNumInferenceSteps = priorNumInferenceSteps;
+        this.priorGuidanceScale = priorGuidanceScale;
+    }
 
     public static CreateKarloImageRequest withUrl(String prompt) {
-        return new CreateKarloImageRequest(prompt, null, "webp", 1, "url");
+        return CreateKarloImageRequest.builder()
+            .prompt(prompt)
+            .imageFormat("webp")
+            .samples(1)
+            .returnType("url")
+            .build();
+    }
+
+    public static CreateKarloImageRequest test(KarloParameter param) {
+        return CreateKarloImageRequest.builder()
+            .prompt(param.getPrompt())
+            .negativePrompt(param.getNegativePrompt())
+            .imageFormat("webp")
+            .samples(param.getSamples())
+            .returnType("url")
+            .priorNumInferenceSteps(param.getPriorNumInferenceSteps())
+            .priorGuidanceScale(param.getPriorGuidanceScale())
+            .build();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/KarloUrlResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/KarloUrlResponse.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.generator.domain.karlo.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,5 +21,11 @@ public class KarloUrlResponse {
 
     public String getUrl(int i) {
         return images.get(0).getImageUrl();
+    }
+
+    public List<String> getUrls() {
+        return images.stream()
+            .map(KarloImageUrlResponse::getImageUrl)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
@@ -2,6 +2,8 @@ package tipitapi.drawmytoday.domain.generator.domain.karlo.service;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -54,16 +56,21 @@ class KarloRequestService {
         }
     }
 
-    byte[] getTestImageAsUrl(KarloParameter karloParameter) throws ImageGeneratorException {
+    List<byte[]> getTestImageAsUrl(KarloParameter karloParameter) throws ImageGeneratorException {
         try {
             HttpEntity<CreateKarloImageRequest> request = getRequest(
                 CreateKarloImageRequest.test(karloParameter));
 
-            String url = Optional.ofNullable(
+            List<String> imageUrls = Optional.ofNullable(
                     restTemplate.postForObject(karloImageCreateUrl, request, KarloUrlResponse.class)
                 ).orElseThrow(KarloRequestFailException::new)
-                .getUrl(0);
-            return new URL(url).openStream().readAllBytes();
+                .getUrls();
+
+            List<byte[]> images = new ArrayList<>();
+            for (String url : imageUrls) {
+                images.add(new URL(url).openStream().readAllBytes());
+            }
+            return images;
         } catch (HttpClientErrorException e) {
             throw new KarloRequestFailException(e);
         } catch (IOException e) {

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
@@ -59,7 +59,7 @@ class KarloRequestService {
     List<byte[]> getTestImageAsUrl(KarloParameter karloParameter) throws ImageGeneratorException {
         try {
             HttpEntity<CreateKarloImageRequest> request = getRequest(
-                CreateKarloImageRequest.test(karloParameter));
+                CreateKarloImageRequest.createTestRequest(karloParameter));
 
             List<String> imageUrls = Optional.ofNullable(
                     restTemplate.postForObject(karloImageCreateUrl, request, KarloUrlResponse.class)

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
 import tipitapi.drawmytoday.domain.generator.domain.karlo.dto.CreateKarloImageRequest;
 import tipitapi.drawmytoday.domain.generator.domain.karlo.dto.KarloUrlResponse;
 import tipitapi.drawmytoday.domain.generator.domain.karlo.exception.KarloRequestFailException;
@@ -40,6 +41,23 @@ class KarloRequestService {
         try {
             HttpEntity<CreateKarloImageRequest> request = getRequest(
                 CreateKarloImageRequest.withUrl(prompt));
+
+            String url = Optional.ofNullable(
+                    restTemplate.postForObject(karloImageCreateUrl, request, KarloUrlResponse.class)
+                ).orElseThrow(KarloRequestFailException::new)
+                .getUrl(0);
+            return new URL(url).openStream().readAllBytes();
+        } catch (HttpClientErrorException e) {
+            throw new KarloRequestFailException(e);
+        } catch (IOException e) {
+            throw new ImageInputStreamFailException();
+        }
+    }
+
+    byte[] getTestImageAsUrl(KarloParameter karloParameter) throws ImageGeneratorException {
+        try {
+            HttpEntity<CreateKarloImageRequest> request = getRequest(
+                CreateKarloImageRequest.test(karloParameter));
 
             String url = Optional.ofNullable(
                     restTemplate.postForObject(karloImageCreateUrl, request, KarloUrlResponse.class)

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.generator.domain.karlo.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,7 +51,8 @@ class KarloService implements ImageGeneratorService {
 
     @Override
     @Transactional(noRollbackFor = ImageGeneratorException.class)
-    public byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException {
+    public List<byte[]> generateTestImage(CreateTestDiaryRequest request)
+        throws ImageGeneratorException {
         KarloParameter param = request.getKarloParameter();
         try {
             return karloRequestService.getTestImageAsUrl(param);

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.diary.service.PromptTextService;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
@@ -42,6 +44,18 @@ class KarloService implements ImageGeneratorService {
             return new GeneratedImageAndPrompt(prompt.getPromptText(), image);
         } catch (ImageGeneratorException e) {
             promptService.createPrompt(prompt.getPromptText(), false);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional(noRollbackFor = ImageGeneratorException.class)
+    public byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException {
+        KarloParameter param = request.getKarloParameter();
+        try {
+            return karloRequestService.getTestImageAsUrl(param);
+        } catch (ImageGeneratorException e) {
+            promptService.createPrompt(param.getPrompt(), false);
             throw e;
         }
     }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/ImageGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/ImageGeneratorService.java
@@ -1,6 +1,7 @@
 package tipitapi.drawmytoday.domain.generator.service;
 
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.generator.dto.GeneratedImageAndPrompt;
 import tipitapi.drawmytoday.domain.generator.exception.ImageGeneratorException;
@@ -11,4 +12,6 @@ public interface ImageGeneratorService {
         throws ImageGeneratorException;
 
     GeneratedImageAndPrompt generateImage(Prompt prompt) throws ImageGeneratorException;
+
+    byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException;
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/ImageGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/ImageGeneratorService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.generator.service;
 
+import java.util.List;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
 import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
@@ -13,5 +14,5 @@ public interface ImageGeneratorService {
 
     GeneratedImageAndPrompt generateImage(Prompt prompt) throws ImageGeneratorException;
 
-    byte[] generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException;
+    List<byte[]> generateTestImage(CreateTestDiaryRequest request) throws ImageGeneratorException;
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- [ POST `/diary` ]: test 쿼리 파라미터 삭제(기존의 테스트 일기 생성 로직 삭제)
- [ POST `/diary/test` ]: 테스트 일기 생성 API 구현
  - TestDiaryController 생성(prod 프로필이 아닐 경우 활성화)
  - 테스트 일기 생성 시 파라미터 추가(prompt, negativePrompt, samples, priorNumInferenceSteps, priorGuidanceScale, seed)

테스트 일기 생성 API가 머지되면 실패하는 테스트 및 테스트 일기 생성 API 테스트 코드 작성하겠습니다. #266 

## 관련 이슈

[일기 생성 API에서 쿼리 파라미터로 테스트 일기 작성하는 로직이 사라졌으니 해당 이슈도 닫겠습니다]
close #137 
close #264 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
