### PR TITLE
테스트 일기 생성 API 테스트코드 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/CreateTestDiaryRequest.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import tipitapi.drawmytoday.common.validator.ValidDiaryDate;
@@ -20,6 +21,7 @@ import tipitapi.drawmytoday.common.validator.ValidDiaryDate;
 @Getter
 @Schema(description = "태스트 일기 생성 Request")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CreateTestDiaryRequest {
 
     @NotNull
@@ -46,6 +48,7 @@ public class CreateTestDiaryRequest {
     private KarloParameter karloParameter;
 
     @Getter
+    @AllArgsConstructor
     public static class KarloParameter {
 
         @NotBlank

--- a/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
+++ b/src/test/java/tipitapi/drawmytoday/common/testdata/TestDiary.java
@@ -22,6 +22,12 @@ public class TestDiary {
         return diary;
     }
 
+    public static Diary createTestDiaryWithId(Long diaryId, User user, Emotion emotion) {
+        Diary diary = createTestDiary(user, emotion);
+        ReflectionTestUtils.setField(diary, "diaryId", diaryId);
+        return diary;
+    }
+
     public static Diary createDiaryWithDate(LocalDateTime diaryDate, User user, Emotion emotion) {
         Diary diary = createDiary(user, emotion);
         ReflectionTestUtils.setField(diary, "diaryDate", diaryDate);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
@@ -303,12 +303,12 @@ class DiaryControllerTest extends ControllerTestSetup {
         }
 
         @Nested
-        @DisplayName("정상 content값이 들어오고, test 쿼리 파라미터가")
-        class If_test_param_is {
+        @DisplayName("정상 content값이 들어온다면")
+        class If_test_param_is_normal {
 
             @Test
-            @DisplayName("없다면 요청한 유저의 일기를 생성한다.")
-            void non_than_create_diary() throws Exception {
+            @DisplayName("요청한 유저의 일기를 생성한다.")
+            void create_diary() throws Exception {
                 // given
                 Long diaryId = 1L;
                 given(createDiaryService.createDiary(
@@ -327,33 +327,6 @@ class DiaryControllerTest extends ControllerTestSetup {
                     .with(SecurityMockMvcRequestPostProcessors.csrf())
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestBody));
-
-                // then
-                result.andExpect(status().isCreated());
-            }
-
-            @Test
-            @DisplayName("true라면 테스트용 일기를 생성한다.")
-            void true_than_create_test_diary() throws Exception {
-                // given
-                Long testDiaryId = 1L;
-                given(createDiaryService.createTestDiary(
-                    REQUEST_USER_ID, emotionId, keyword, notes, diaryDate, userTime))
-                    .willReturn(new CreateDiaryResponse(testDiaryId));
-
-                // when
-                Map<String, Object> requestMap = new HashMap<>();
-                requestMap.put("emotionId", emotionId);
-                requestMap.put("keyword", keyword);
-                requestMap.put("notes", notes);
-                requestMap.put("diaryDate", diaryDate);
-                String requestBody = objectMapper.writeValueAsString(requestMap);
-
-                ResultActions result = mockMvc.perform(post(BASIC_URL)
-                    .with(SecurityMockMvcRequestPostProcessors.csrf())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody)
-                    .queryParam("test", "true"));
 
                 // then
                 result.andExpect(status().isCreated());

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/TestDiaryControllerTest.java
@@ -1,0 +1,135 @@
+package tipitapi.drawmytoday.domain.diary.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.ResultActions;
+import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
+import tipitapi.drawmytoday.common.controller.WithCustomUser;
+import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
+import tipitapi.drawmytoday.domain.diary.service.CreateDiaryService;
+
+@WebMvcTest(TestDiaryController.class)
+@WithCustomUser
+class TestDiaryControllerTest extends ControllerTestSetup {
+
+    private static final String BASIC_URL = "/diary";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CreateDiaryService createDiaryService;
+
+    @DisplayName("createTestDiary 메서드는")
+    @Nested
+    class CreateTestDiaryTest {
+
+        @BeforeEach
+        void beforeAll() {
+            requestMap = new HashMap<>();
+            requestMap.put("emotionId", 1L);
+            requestMap.put("notes", "notes");
+            requestMap.put("diaryDate", LocalDate.now());
+            requestMap.put("userTime",
+                LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
+        }
+
+        private Map<String, Object> requestMap;
+        private final String prompt = "prompt";
+        private final String negativePrompt = "negativePrompt";
+        private final Integer samples = 3;
+        private final Integer priorNumInferenceSteps = 10;
+        private final Double priorGuidanceScale = 50D;
+        private final Long[] seed = new Long[]{1L, 2L, 3L};
+
+        @DisplayName("request body에 들어온 karloParam 중")
+        @Nested
+        class Request_body_karlo_param_is {
+
+            @DisplayName("프롬프트 필드가 비었다면 400 에러를 반환한다")
+            @ParameterizedTest
+            @ValueSource(strings = {"", " ", "  "})
+            void it_returns_400_if_prompt_field_is_blank(String prompt) throws Exception {
+                // given
+                KarloParameter karloParameter = new KarloParameter(prompt, negativePrompt,
+                    samples, priorNumInferenceSteps, priorGuidanceScale, seed);
+                requestMap.put("karloParameter", karloParameter);
+                String requestBody = objectMapper.writeValueAsString(requestMap);
+
+                // when
+                ResultActions result = mockMvc.perform(post(BASIC_URL + "/test")
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+                // then
+                result.andExpect(status().isBadRequest());
+            }
+
+            @DisplayName("samples 필드가 양수가 아니면 400 에러를 반환한다")
+            @ParameterizedTest
+            @ValueSource(ints = {-1, 0})
+            void it_returns_400_if_samples_not_positive(int samples) throws Exception {
+                // given
+                KarloParameter karloParameter = new KarloParameter(prompt, negativePrompt,
+                    samples, priorNumInferenceSteps, priorGuidanceScale, seed);
+                requestMap.put("karloParameter", karloParameter);
+                String requestBody = objectMapper.writeValueAsString(requestMap);
+
+                // when
+                ResultActions result = mockMvc.perform(post(BASIC_URL + "/test")
+                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody));
+
+                // then
+                result.andExpect(status().isBadRequest());
+            }
+        }
+
+        @DisplayName("테스트 일기 생성에 성공하면 201 응답을 반환한다")
+        @Test
+        void it_returns_201_if_create_test_diary_success() throws Exception {
+            // given
+            CreateDiaryResponse createDiaryResponse = new CreateDiaryResponse(1L);
+            given(createDiaryService.createTestDiary(anyLong(), any(CreateTestDiaryRequest.class)))
+                .willReturn(createDiaryResponse);
+            KarloParameter karloParameter = new KarloParameter(prompt, negativePrompt,
+                samples, priorNumInferenceSteps, priorGuidanceScale, seed);
+            requestMap.put("karloParameter", karloParameter);
+            String requestBody = objectMapper.writeValueAsString(requestMap);
+
+            // when
+            ResultActions result = mockMvc.perform(post(BASIC_URL + "/test")
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+            // then
+            result.andExpect(status().isCreated());
+        }
+    }
+
+}

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryServiceTest.java
@@ -3,16 +3,20 @@ package tipitapi.drawmytoday.domain.diary.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,14 +34,16 @@ import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
 import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
 import tipitapi.drawmytoday.domain.diary.exception.PromptNotExistException;
 import tipitapi.drawmytoday.domain.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.emotion.service.ValidateEmotionService;
 import tipitapi.drawmytoday.domain.generator.domain.dalle.exception.DallERequestFailException;
-import tipitapi.drawmytoday.domain.generator.domain.dalle.service.DallEService;
 import tipitapi.drawmytoday.domain.generator.dto.GeneratedImageAndPrompt;
 import tipitapi.drawmytoday.domain.generator.exception.ImageInputStreamFailException;
+import tipitapi.drawmytoday.domain.generator.service.ImageGeneratorService;
 import tipitapi.drawmytoday.domain.ticket.service.ValidateTicketService;
 import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
@@ -60,11 +66,9 @@ class CreateDiaryServiceTest {
     @Mock
     private ValidateTicketService validateTicketService;
     @Mock
-    private DallEService dallEService;
+    private ImageGeneratorService imageGeneratorService;
     @Mock
     private PromptService promptService;
-    @Mock
-    private PromptTextService promptTextService;
     @Mock
     private Encryptor encryptor;
 
@@ -80,7 +84,7 @@ class CreateDiaryServiceTest {
         private final LocalTime USER_TIME = LocalTime.now();
 
         @Nested
-        @DisplayName("dallE 요청 시")
+        @DisplayName("dallE imageGenerator로 요청 시")
         class DallE_request {
 
             @ParameterizedTest
@@ -97,7 +101,7 @@ class CreateDiaryServiceTest {
 
                 given(validateUserService.validateUserById(USER_ID)).willReturn(user);
                 given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
-                given(dallEService.generateImage(eq(emotion), eq(KEYWORD))).willThrow(
+                given(imageGeneratorService.generateImage(eq(emotion), eq(KEYWORD))).willThrow(
                     exceptionClass);
 
                 //when
@@ -110,40 +114,40 @@ class CreateDiaryServiceTest {
                 verify(promptService, never()).createPrompt(any(Diary.class), anyString(),
                     eq(true));
             }
+        }
 
-            @Test
-            @DisplayName("정상일 경우 일기를 생성한다.")
-            void success_then_create_diary() throws Exception {
-                //given
-                Long diaryId = 1L;
-                LocalDateTime lastDateTime = DIARY_DATE.minusDays(1L).atTime(1, 1);
-                String prompt = "test prompt";
-                byte[] image = new byte[1];
+        @Test
+        @DisplayName("일기를 생성한다.")
+        void create_diary() throws Exception {
+            //given
+            Long diaryId = 1L;
+            LocalDateTime lastDateTime = DIARY_DATE.minusDays(1L).atTime(1, 1);
+            String prompt = "test prompt";
+            byte[] image = new byte[1];
 
-                User user = TestUser.createUserWithId(USER_ID);
-                user.setLastDiaryDate(lastDateTime);
-                Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
-                Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
+            User user = TestUser.createUserWithId(USER_ID);
+            user.setLastDiaryDate(lastDateTime);
+            Emotion emotion = TestEmotion.createEmotionWithId(EMOTION_ID);
+            Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
 
-                given(validateUserService.validateUserById(USER_ID)).willReturn(user);
-                given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
-                given(dallEService.generateImage(emotion, KEYWORD)).willReturn(
-                    new GeneratedImageAndPrompt(prompt, image));
-                given(encryptor.encrypt(NOTES)).willReturn("암호화된 노트");
-                given(diaryRepository.save(any(Diary.class))).willReturn(diary);
+            given(validateUserService.validateUserById(USER_ID)).willReturn(user);
+            given(validateEmotionService.validateEmotionById(EMOTION_ID)).willReturn(emotion);
+            given(imageGeneratorService.generateImage(emotion, KEYWORD)).willReturn(
+                new GeneratedImageAndPrompt(prompt, image));
+            given(encryptor.encrypt(NOTES)).willReturn("암호화된 노트");
+            given(diaryRepository.save(any(Diary.class))).willReturn(diary);
 
-                //when
-                CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
-                    USER_ID, EMOTION_ID, KEYWORD, NOTES, DIARY_DATE, USER_TIME);
+            //when
+            CreateDiaryResponse createDiaryResponse = createDiaryService.createDiary(
+                USER_ID, EMOTION_ID, KEYWORD, NOTES, DIARY_DATE, USER_TIME);
 
-                //then
-                assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
-                assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
+            //then
+            assertThat(createDiaryResponse.getId()).isEqualTo(diaryId);
+            assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
 
-                verify(dallEService).generateImage(eq(emotion), eq(KEYWORD));
-                verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
-                verify(imageService).uploadAndCreateImage(eq(diary), any(byte[].class), eq(true));
-            }
+            verify(imageGeneratorService).generateImage(eq(emotion), eq(KEYWORD));
+            verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
+            verify(imageService).uploadAndCreateImage(eq(diary), any(byte[].class), eq(true));
         }
     }
 
@@ -151,42 +155,38 @@ class CreateDiaryServiceTest {
     @DisplayName("createTestDiary 메서드는")
     class Create_test_diary_test {
 
-        @Test
-        @DisplayName("그림을 생성하지 않는다.")
-        void not_draw_image() throws Exception {
-            //given
-            Long userId = 1L;
-            LocalDate diaryDate = LocalDate.now();
-            LocalTime userTime = LocalTime.now();
-            Long emotionId = 1L;
-            Long diaryId = 1L;
-            String prompt = "test prompt";
-            String notes = "노트";
-            String keyword = "키워드";
-            LocalDateTime lastDateTime = diaryDate.minusDays(1L).atTime(1, 1);
+        @DisplayName("samples 수에 따라 테스트 일기를 생성한다.")
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2, 3})
+        void create_test_diary(int samples) throws Exception {
+            // given
+            KarloParameter karloParameter = new KarloParameter("prompt", "negativePrompt",
+                samples, 10, 10D, null);
+            CreateTestDiaryRequest request = new CreateTestDiaryRequest(1L, "notes",
+                LocalDate.now(), LocalTime.now(), karloParameter);
+            User user = TestUser.createAdminUserWithId(1L);
+            Emotion emotion = TestEmotion.createEmotionWithId(2L);
+            Diary testDiary = TestDiary.createTestDiaryWithId(3L, user, emotion);
+            given(validateUserService.validateAdminUserById(any(Long.class)))
+                .willReturn(user);
+            given(validateEmotionService.validateEmotionById(any(Long.class)))
+                .willReturn(emotion);
+            given(diaryRepository.save(any(Diary.class)))
+                .willReturn(testDiary);
+            List<byte[]> images = IntStream.rangeClosed(1, samples)
+                .mapToObj(i -> new byte[1])
+                .toList();
+            given(imageGeneratorService.generateTestImage(any(CreateTestDiaryRequest.class)))
+                .willReturn(images);
 
-            User user = TestUser.createUserWithId(userId);
-            user.setLastDiaryDate(lastDateTime);
-            Emotion emotion = TestEmotion.createEmotionWithId(emotionId);
-            Diary diary = TestDiary.createDiaryWithId(diaryId, user, emotion);
+            // when
+            CreateDiaryResponse response = createDiaryService.createTestDiary(user.getUserId(),
+                request);
 
-            given(validateUserService.validateAdminUserById(userId)).willReturn(user);
-            given(validateEmotionService.validateEmotionById(emotionId)).willReturn(emotion);
-            given(encryptor.encrypt(notes)).willReturn("암호화된 노트");
-            given(diaryRepository.save(any(Diary.class))).willReturn(diary);
-            given(promptTextService.createPromptText(emotion, keyword)).willReturn(prompt);
-
-            //when
-            CreateDiaryResponse response = createDiaryService.createTestDiary(
-                userId, emotionId, keyword, notes, diaryDate, userTime);
-
-            //then
-            assertThat(response.getId()).isEqualTo(diaryId);
-            assertThat(user.getLastDiaryDate().isAfter(lastDateTime)).isTrue();
-
-            verify(dallEService, never()).generateImage(any(Emotion.class), any(String.class));
-            verify(promptService).createPrompt(eq(diary), eq(prompt), eq(true));
-            verify(imageService).createImage(eq(diary), any(String.class), eq(true));
+            // then
+            assertThat(response.getId()).isEqualTo(testDiary.getDiaryId());
+            verify(imageService, times(samples)).uploadAndCreateImage(any(Diary.class),
+                any(byte[].class), anyBoolean());
         }
     }
 
@@ -232,7 +232,7 @@ class CreateDiaryServiceTest {
             given(validateDiaryService.validateDiaryById(any(Long.class), any(User.class)))
                 .willReturn(diary);
             given(promptService.getPromptByDiaryId(eq(diaryId))).willReturn(Optional.of(prompt));
-            given(dallEService.generateImage(eq(prompt)))
+            given(imageGeneratorService.generateImage(eq(prompt)))
                 .willReturn(new GeneratedImageAndPrompt(promptText, image));
 
             //when

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/ImageServiceTest.java
@@ -88,7 +88,7 @@ class ImageServiceTest {
             Long diaryId = 1L;
             Diary diary = createDiaryWithId(diaryId, createUser(), createEmotion());
             Image image = createImageWithId(1L, diary);
-            String imagePathRegex = "post/" + diaryId + "/\\d+_1.png";
+            String imagePathRegex = "post/" + diaryId + "/\\d+_1.webp";
 
             given(imageRepository.save(any(Image.class))).willReturn(image);
 

--- a/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestServiceTest.java
@@ -1,0 +1,197 @@
+package tipitapi.drawmytoday.domain.generator.domain.karlo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
+import tipitapi.drawmytoday.domain.generator.domain.karlo.dto.KarloImageUrlResponse;
+import tipitapi.drawmytoday.domain.generator.domain.karlo.dto.KarloUrlResponse;
+import tipitapi.drawmytoday.domain.generator.domain.karlo.exception.KarloRequestFailException;
+import tipitapi.drawmytoday.domain.generator.exception.ImageInputStreamFailException;
+
+@ExtendWith(MockitoExtension.class)
+class KarloRequestServiceTest {
+
+    @Mock
+    RestTemplate restTemplate;
+
+    String karloImageCreateUrl = "karlo-api-url";
+
+    KarloRequestService karloRequestService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.karloRequestService = new KarloRequestService(restTemplate, karloImageCreateUrl);
+    }
+
+    @Nested
+    @DisplayName("getImageAsUrl 메서드 테스트")
+    class GetImageAsUrl_test {
+
+        @Nested
+        @DisplayName("karlo 요청을 보내고")
+        class Send_karlo_request {
+
+            @Test
+            @DisplayName("응답이 없으면 예외를 던진다")
+            void when_response_is_null_then_throw_exception() {
+                // given
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(null);
+
+                // when
+                // then
+                assertThatThrownBy(() -> karloRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(KarloRequestFailException.class);
+            }
+
+            @Test
+            @DisplayName("비정상적인 응답이 오면 예외를 던진다")
+            void when_invalid_response_then_throw_exception() throws Exception {
+                // given
+                HttpClientErrorException badRequest = new HttpClientErrorException(
+                    HttpStatus.BAD_REQUEST, "bad request");
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willThrow(badRequest);
+
+                // when
+                // then
+                assertThatThrownBy(() -> karloRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(KarloRequestFailException.class);
+            }
+
+            @Test
+            @DisplayName("응답받은 url에 해당하는 이미지를 가져올 수 없다면 예외를 던진다")
+            void when_get_image_fail_then_throw_exception() {
+                // given
+                KarloImageUrlResponse karloImageUrlResponse = new KarloImageUrlResponse(
+                    "id", 1L, "invalid url");
+                KarloUrlResponse response = new KarloUrlResponse(
+                    "id", "modelVersion", List.of(karloImageUrlResponse));
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(response);
+
+                // when
+                // then
+                assertThatThrownBy(() -> karloRequestService.getImageAsUrl("prompt"))
+                    .isInstanceOf(ImageInputStreamFailException.class);
+            }
+
+            @Test
+            @DisplayName("정상적인 응답이 오면 응답받은 url에 해당하는 이미지를 가져온다")
+            void when_get_image_success_then_return_image() throws Exception {
+                // given
+                KarloImageUrlResponse karloImageUrlResponse = new KarloImageUrlResponse(
+                    "id", 1L, "https://google.com");
+                KarloUrlResponse response = new KarloUrlResponse(
+                    "id", "modelVersion", List.of(karloImageUrlResponse));
+                given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                    any(Class.class))).willReturn(response);
+
+                // when
+                byte[] image = karloRequestService.getImageAsUrl("prompt");
+
+                // then
+                assertThat(image).isNotNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getTestImageAsUrl 테스트")
+    class GetTestImageAsUrl_test {
+
+        @Test
+        @DisplayName("응답이 없으면 예외를 던진다")
+        void when_response_is_null_then_throw_exception() {
+            // given
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willReturn(null);
+
+            // when
+            // then
+            assertThatThrownBy(() -> karloRequestService.getTestImageAsUrl(getKarloParameter()))
+                .isInstanceOf(KarloRequestFailException.class);
+        }
+
+        @Test
+        @DisplayName("비정상적인 응답이 오면 예외를 던진다")
+        void when_invalid_response_then_throw_exception() throws Exception {
+            // given
+            HttpClientErrorException badRequest = new HttpClientErrorException(
+                HttpStatus.BAD_REQUEST, "bad request");
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willThrow(badRequest);
+
+            // when
+            // then
+            assertThatThrownBy(() -> karloRequestService.getTestImageAsUrl(getKarloParameter()))
+                .isInstanceOf(KarloRequestFailException.class);
+        }
+
+        @Test
+        @DisplayName("응답받은 url에 해당하는 이미지를 가져올 수 없다면 예외를 던진다")
+        void when_get_image_fail_then_throw_exception() {
+            // given
+            KarloImageUrlResponse karloImageUrlResponse = new KarloImageUrlResponse(
+                "id", 1L, "invalid url");
+            KarloUrlResponse response = new KarloUrlResponse(
+                "id", "modelVersion", List.of(karloImageUrlResponse));
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willReturn(response);
+
+            // when
+            // then
+            assertThatThrownBy(() -> karloRequestService.getTestImageAsUrl(getKarloParameter()))
+                .isInstanceOf(ImageInputStreamFailException.class);
+        }
+
+        @Test
+        @DisplayName("정상적인 응답이 오면 응답받은 url에 해당하는 이미지들을 가져온다")
+        void when_get_image_success_then_return_image() throws Exception {
+            // given
+            KarloImageUrlResponse karloImageUrlResponse1 = new KarloImageUrlResponse(
+                "id1", 1L, "https://google.com");
+            KarloImageUrlResponse karloImageUrlResponse2 = new KarloImageUrlResponse(
+                "id2", 2L, "https://google.com");
+            KarloUrlResponse response = new KarloUrlResponse(
+                "id", "modelVersion",
+                List.of(karloImageUrlResponse1, karloImageUrlResponse2));
+            given(restTemplate.postForObject(any(String.class), any(HttpEntity.class),
+                any(Class.class))).willReturn(response);
+
+            // when
+            List<byte[]> testImages = karloRequestService.getTestImageAsUrl(getKarloParameter());
+
+            // then
+            assertThat(testImages).hasSize(2);
+        }
+
+        private KarloParameter getKarloParameter() {
+            return new KarloParameter(
+                "prompt",
+                "negativePrompt",
+                2,
+                10,
+                50D,
+                new Long[]{1L, 2L}
+            );
+        }
+    }
+}

--- a/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloServiceTest.java
@@ -8,6 +8,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tipitapi.drawmytoday.common.testdata.TestPrompt;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
+import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest.KarloParameter;
 import tipitapi.drawmytoday.domain.diary.service.PromptService;
 import tipitapi.drawmytoday.domain.generator.domain.karlo.exception.KarloRequestFailException;
 import tipitapi.drawmytoday.domain.generator.dto.GeneratedImageAndPrompt;
@@ -30,12 +35,12 @@ class KarloServiceTest {
     @InjectMocks
     KarloService karloService;
 
-    @DisplayName("generateImage(Prompt) 메서드는")
     @Nested
-    class GenerateImageTest {
+    @DisplayName("generateImage(Prompt) 메서드 테스트")
+    class GenerateImage_test {
 
-        @DisplayName("karlo 요청을 실패할 경우 fail prompt를 저장한다.")
         @Test
+        @DisplayName("karlo 요청을 실패할 경우 fail prompt를 저장한다.")
         void karlo_request_fail_then_generateImage_fail() throws Exception {
             // given
             String prompt = "prompt";
@@ -50,8 +55,8 @@ class KarloServiceTest {
             verify(promptService).createPrompt(any(String.class), eq(false));
         }
 
-        @DisplayName("karlo 요청을 성공할 경우 성공한 prompt를 저장한다.")
         @Test
+        @DisplayName("karlo 요청을 성공할 경우 성공한 prompt를 저장한다.")
         void karlo_request_success_then_generateImage_success() throws Exception {
             // given
             String prompt = "prompt";
@@ -69,4 +74,46 @@ class KarloServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("generateTestImage 메서드 테스트")
+    class GenerateTestImage_test {
+
+        @Test
+        @DisplayName("karlo 요청을 실패할 경우 fail prompt를 저장한다.")
+        void karlo_request_fail_then_generateImage_fail() throws Exception {
+            // given
+            KarloParameter karloParameter = new KarloParameter("prompt", "negativePrompt",
+                1, 10, 10D, null);
+            CreateTestDiaryRequest request = new CreateTestDiaryRequest(1L, "notes",
+                LocalDate.now(), LocalTime.now(), karloParameter);
+            given(karloRequestService.getTestImageAsUrl(any(KarloParameter.class)))
+                .willThrow(KarloRequestFailException.class);
+
+            // when
+            // then
+            assertThatThrownBy(() -> karloService.generateTestImage(request))
+                .isInstanceOf(KarloRequestFailException.class);
+            verify(promptService).createPrompt(any(String.class), eq(false));
+        }
+
+        @Test
+        @DisplayName("karlo 요청을 성공할 경우 이미지들을 반환한다.")
+        void karlo_request_success_then_return_images() throws Exception {
+            // given
+            KarloParameter karloParameter = new KarloParameter("prompt", "negativePrompt",
+                1, 10, 10D, null);
+            CreateTestDiaryRequest request = new CreateTestDiaryRequest(1L, "notes",
+                LocalDate.now(), LocalTime.now(), karloParameter);
+            List<byte[]> images = List.of(new byte[0]);
+            given(karloRequestService.getTestImageAsUrl(any(KarloParameter.class)))
+                .willReturn(images);
+
+            // when
+            List<byte[]> returnImages = karloService.generateTestImage(request);
+
+            // then
+            verify(promptService, never()).createPrompt(any(String.class), eq(false));
+            assertThat(returnImages).isEqualTo(images);
+        }
+    }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloServiceTest.java
@@ -1,0 +1,72 @@
+package tipitapi.drawmytoday.domain.generator.domain.karlo.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tipitapi.drawmytoday.common.testdata.TestPrompt;
+import tipitapi.drawmytoday.domain.diary.service.PromptService;
+import tipitapi.drawmytoday.domain.generator.domain.karlo.exception.KarloRequestFailException;
+import tipitapi.drawmytoday.domain.generator.dto.GeneratedImageAndPrompt;
+
+@ExtendWith(MockitoExtension.class)
+class KarloServiceTest {
+
+    @Mock
+    PromptService promptService;
+    @Mock
+    KarloRequestService karloRequestService;
+    @InjectMocks
+    KarloService karloService;
+
+    @DisplayName("generateImage(Prompt) 메서드는")
+    @Nested
+    class GenerateImageTest {
+
+        @DisplayName("karlo 요청을 실패할 경우 fail prompt를 저장한다.")
+        @Test
+        void karlo_request_fail_then_generateImage_fail() throws Exception {
+            // given
+            String prompt = "prompt";
+            given(karloRequestService.getImageAsUrl(eq(prompt)))
+                .willThrow(KarloRequestFailException.class);
+
+            // when
+            // then
+            assertThatThrownBy(() -> karloService.generateImage(
+                TestPrompt.createPromptWithId(1L, prompt)))
+                .isInstanceOf(KarloRequestFailException.class);
+            verify(promptService).createPrompt(any(String.class), eq(false));
+        }
+
+        @DisplayName("karlo 요청을 성공할 경우 성공한 prompt를 저장한다.")
+        @Test
+        void karlo_request_success_then_generateImage_success() throws Exception {
+            // given
+            String prompt = "prompt";
+            byte[] image = new byte[0];
+            given(karloRequestService.getImageAsUrl(eq(prompt))).willReturn(image);
+
+            // when
+            GeneratedImageAndPrompt generatedImageAndPrompt = karloService.generateImage(
+                TestPrompt.createPromptWithId(1L, prompt));
+
+            // then
+            verify(promptService, never()).createPrompt(any(String.class), eq(false));
+            assertThat(generatedImageAndPrompt.getPrompt()).isEqualTo(prompt);
+            assertThat(generatedImageAndPrompt.getImage()).isEqualTo(image);
+        }
+    }
+
+}


### PR DESCRIPTION
# 구현 내용

테스트 일기 생성 API가 추가됨에 따라 바뀌거나 새로 만들어진 메서드에 대한 테스트 코드를 작성했습니다. 또한, karloService, KarloRequestService 클래스의 테스트코드가 없어서 이번에 작성했습니다.

## 구현 요약

- TestDiaryControllerTest 추가
  - 테스트 일기 생성 API 검증
- karloServiceTest 추가
  - generateImage(Prompt Prompt), generateTestImage 메서드 검증
- karloRequestServiceTest 추가
  - getImageAsUrl, getTestImageAsUrl 메서드 검증


## 관련 이슈

close #266 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
