### PR TITLE
[관리자 일기 조회 API] 테스트 일기가 반환되도록 개선

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
@@ -51,10 +51,12 @@ public class AdminController {
         @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
         @Parameter(name = "emotion", description = "필터링할 감정 ID", in = ParameterIn.QUERY)
         @RequestParam(name = "emotion", required = false) Long emotionId,
+        @Parameter(name = "test", description = "테스트용 일기 포함 여부", in = ParameterIn.QUERY)
+        @RequestParam(name = "test", required = false, defaultValue = "true") boolean test,
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            adminService.getDiaries(tokenInfo.getUserId(), size, page, direction, emotionId)
+            adminService.getDiaries(tokenInfo.getUserId(), size, page, direction, emotionId, test)
         ).asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
@@ -51,12 +51,13 @@ public class AdminController {
         @RequestParam(name = "direction", required = false, defaultValue = "DESC") Direction direction,
         @Parameter(name = "emotion", description = "필터링할 감정 ID", in = ParameterIn.QUERY)
         @RequestParam(name = "emotion", required = false) Long emotionId,
-        @Parameter(name = "test", description = "테스트용 일기 포함 여부", in = ParameterIn.QUERY)
-        @RequestParam(name = "test", required = false, defaultValue = "true") boolean test,
+        @Parameter(name = "with_test", description = "테스트용 일기 포함 여부", in = ParameterIn.QUERY)
+        @RequestParam(name = "with_test", required = false, defaultValue = "true") boolean withTest,
         @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            adminService.getDiaries(tokenInfo.getUserId(), size, page, direction, emotionId, test)
+            adminService.getDiaries(tokenInfo.getUserId(), size, page, direction, emotionId,
+                withTest)
         ).asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryAdminResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryAdminResponse.java
@@ -38,15 +38,19 @@ public class GetDiaryAdminResponse {
     @Schema(description = "평가 점수 (1~5 사이의 숫자)")
     private final String review;
 
+    @Schema(description = "테스트 일기 여부", requiredMode = RequiredMode.REQUIRED)
+    private final boolean isTest;
+
     @QueryProjection
     public GetDiaryAdminResponse(Long id, String imageURL, String prompt,
-        LocalDateTime createdAt, LocalDateTime imageCreatedAt, String review) {
+        LocalDateTime createdAt, LocalDateTime imageCreatedAt, String review, boolean isTest) {
         this.id = id;
         this.imageURL = imageURL;
         this.prompt = prompt;
         this.createdAt = createdAt;
         this.imageCreatedAt = imageCreatedAt;
         this.review = review;
+        this.isTest = isTest;
     }
 
     public void updateImageUrl(String imageUrl) {

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
@@ -18,8 +18,8 @@ public class AdminService {
     private final AdminDiaryService adminDiaryService;
 
     public Page<GetDiaryAdminResponse> getDiaries(Long userId, int size, int page,
-        Direction direction, Long emotionId) {
+        Direction direction, Long emotionId, boolean test) {
         validateUserService.validateAdminUserById(userId);
-        return adminDiaryService.getDiaries(size, page, direction, emotionId);
+        return adminDiaryService.getDiaries(size, page, direction, emotionId, test);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
@@ -18,8 +18,8 @@ public class AdminService {
     private final AdminDiaryService adminDiaryService;
 
     public Page<GetDiaryAdminResponse> getDiaries(Long userId, int size, int page,
-        Direction direction, Long emotionId, boolean test) {
+        Direction direction, Long emotionId, boolean withTest) {
         validateUserService.validateAdminUserById(userId);
-        return adminDiaryService.getDiaries(size, page, direction, emotionId, test);
+        return adminDiaryService.getDiaries(size, page, direction, emotionId, withTest);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
@@ -14,7 +14,7 @@ import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
 public interface DiaryQueryRepository {
 
     Page<GetDiaryAdminResponse> getDiariesForMonitorAsPage(Pageable pageable,
-        Direction direction, Long emotionId, boolean test);
+        Direction direction, Long emotionId, boolean withTest);
 
     Optional<Diary> getDiaryExistsByDiaryDate(Long userId, LocalDate diaryDate);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
@@ -14,7 +14,7 @@ import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
 public interface DiaryQueryRepository {
 
     Page<GetDiaryAdminResponse> getDiariesForMonitorAsPage(Pageable pageable,
-        Direction direction, Long emotionId);
+        Direction direction, Long emotionId, boolean test);
 
     Optional<Diary> getDiaryExistsByDiaryDate(Long userId, LocalDate diaryDate);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -31,9 +31,9 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
 
     @Override
     public Page<GetDiaryAdminResponse> getDiariesForMonitorAsPage(Pageable pageable,
-        Direction direction, Long emotionId, boolean test) {
+        Direction direction, Long emotionId, boolean withTest) {
 
-        BooleanExpression withoutTest = test ? null : diary.isTest.eq(false);
+        BooleanExpression withoutTest = withTest ? null : diary.isTest.eq(false);
         BooleanExpression withEmotion = null;
         if (emotionId != null) {
             Emotion filterEmotion = queryFactory.selectFrom(emotion)

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -31,9 +31,9 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
 
     @Override
     public Page<GetDiaryAdminResponse> getDiariesForMonitorAsPage(Pageable pageable,
-        Direction direction, Long emotionId) {
+        Direction direction, Long emotionId, boolean test) {
 
-        BooleanExpression withoutTest = diary.isTest.eq(false);
+        BooleanExpression withoutTest = test ? null : diary.isTest.eq(false);
         BooleanExpression withEmotion = null;
         if (emotionId != null) {
             Emotion filterEmotion = queryFactory.selectFrom(emotion)

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -46,7 +46,7 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
 
         List<GetDiaryAdminResponse> content = queryFactory.select(
                 new QGetDiaryAdminResponse(diary.diaryId, image.imageUrl, prompt.promptText,
-                    diary.createdAt, image.createdAt, image.review))
+                    diary.createdAt, image.createdAt, image.review, diary.isTest))
             .from(diary)
             .leftJoin(image).on(diary.diaryId.eq(image.diary.diaryId))
             .leftJoin(prompt).on(diary.diaryId.eq(prompt.diary.diaryId))

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
@@ -22,9 +22,9 @@ public class AdminDiaryService {
     private int imageExpiration;
 
     public Page<GetDiaryAdminResponse> getDiaries(int size, int page, Direction direction,
-        Long emotionId) {
+        Long emotionId, boolean test) {
         return diaryRepository.getDiariesForMonitorAsPage(
-                Pageable.ofSize(size).withPage(page), direction, emotionId)
+                Pageable.ofSize(size).withPage(page), direction, emotionId, test)
             .map(this::generatePresignedURL);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
@@ -22,9 +22,9 @@ public class AdminDiaryService {
     private int imageExpiration;
 
     public Page<GetDiaryAdminResponse> getDiaries(int size, int page, Direction direction,
-        Long emotionId, boolean test) {
+        Long emotionId, boolean withTest) {
         return diaryRepository.getDiariesForMonitorAsPage(
-                Pageable.ofSize(size).withPage(page), direction, emotionId, test)
+                Pageable.ofSize(size).withPage(page), direction, emotionId, withTest)
             .map(this::generatePresignedURL);
     }
 

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.admin.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -59,7 +60,7 @@ class AdminControllerTest extends ControllerTestSetup {
                 "angry , blue , glass-textured, crayon, school",
                 LocalDateTime.now().minusDays(1), LocalDateTime.now(), "3"));
             given(adminService.getDiaries(anyLong(), anyInt(), anyInt(), any(Direction.class),
-                anyLong()))
+                anyLong(), eq(true)))
                 .willReturn(new PageImpl<>(diaries, pageable, 2));
 
             // when

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/controller/AdminControllerTest.java
@@ -54,11 +54,11 @@ class AdminControllerTest extends ControllerTestSetup {
             diaries.add(new GetDiaryAdminResponse(1L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                 "happy , pink , canvas-textured, Oil Pastel, a crowded subway",
-                LocalDateTime.now().minusDays(5), LocalDateTime.now(), null));
+                LocalDateTime.now().minusDays(5), LocalDateTime.now(), null, false));
             diaries.add(new GetDiaryAdminResponse(2L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                 "angry , blue , glass-textured, crayon, school",
-                LocalDateTime.now().minusDays(1), LocalDateTime.now(), "3"));
+                LocalDateTime.now().minusDays(1), LocalDateTime.now(), "3", false));
             given(adminService.getDiaries(anyLong(), anyInt(), anyInt(), any(Direction.class),
                 anyLong(), eq(true)))
                 .willReturn(new PageImpl<>(diaries, pageable, 2));

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
@@ -75,11 +75,11 @@ class AdminServiceTest {
                 diaries.add(new GetDiaryAdminResponse(1L,
                     "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                     "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
-                    LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4"));
+                    LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4", false));
                 diaries.add(new GetDiaryAdminResponse(2L,
                     "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                     "angry , purple , canvas-textured, Oil Pastel, school",
-                    LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), "3"));
+                    LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), "3", false));
                 given(adminDiaryService.getDiaries(any(Integer.class), any(Integer.class),
                     any(Direction.class), anyLong(), anyBoolean())).willReturn(
                     new PageImpl<>(diaries));

--- a/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/admin/service/AdminServiceTest.java
@@ -3,6 +3,7 @@ package tipitapi.drawmytoday.domain.admin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static tipitapi.drawmytoday.common.testdata.TestUser.createAdminUserWithId;
@@ -53,7 +54,8 @@ class AdminServiceTest {
 
                 // when
                 // then
-                assertThatThrownBy(() -> adminService.getDiaries(1L, 10, 0, Direction.ASC, 1L))
+                assertThatThrownBy(
+                    () -> adminService.getDiaries(1L, 10, 0, Direction.ASC, 1L, true))
                     .isInstanceOf(UserAccessDeniedException.class);
             }
         }
@@ -79,11 +81,12 @@ class AdminServiceTest {
                     "angry , purple , canvas-textured, Oil Pastel, school",
                     LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), "3"));
                 given(adminDiaryService.getDiaries(any(Integer.class), any(Integer.class),
-                    any(Direction.class), anyLong())).willReturn(new PageImpl<>(diaries));
+                    any(Direction.class), anyLong(), anyBoolean())).willReturn(
+                    new PageImpl<>(diaries));
 
                 // when
                 Page<GetDiaryAdminResponse> response = adminService.getDiaries(1L, 10, 0,
-                    Direction.ASC, 1L);
+                    Direction.ASC, 1L, true);
 
                 // then
                 assertThat(response.getContent().size()).isEqualTo(2);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/DiaryRepositoryTest.java
@@ -303,11 +303,13 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                     Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
                         Pageable.ofSize(size).withPage(page), Direction.DESC, null, true);
 
-                    assertThat(response.get()
+                    Optional<GetDiaryAdminResponse> testDiaryResponse = response.get()
                         .filter(
                             diaryResponse -> Objects.equals(diaryResponse.getId(),
                                 diary.getDiaryId()))
-                        .findAny()).isPresent();
+                        .findAny();
+                    assertThat(testDiaryResponse).isPresent();
+                    assertThat(testDiaryResponse.get().isTest()).isTrue();
                 }
             }
         }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/repository/DiaryRepositoryTest.java
@@ -245,7 +245,7 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                 int page = 0;
                 int size = 5;
                 Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
-                    Pageable.ofSize(size).withPage(page), Direction.DESC, null);
+                    Pageable.ofSize(size).withPage(page), Direction.DESC, null, true);
 
                 assertThat(response.getTotalElements()).isEqualTo(10);
                 assertThat(response.getContent().size()).isEqualTo(5);
@@ -256,27 +256,59 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
         }
 
         @Nested
-        @DisplayName("더미 이미지가 있을 경우")
-        class if_dummy_image_exist {
+        @DisplayName("테스트 일기가 있을 경우")
+        class if_test_diary_exist {
 
-            @Test
-            @DisplayName("더미 이미지를 제외한 일기 리스트를 반환한다.")
-            @Sql("GetDiariesForMonitorAsPageTest.sql")
-            void return_diary_list_excludes_dummy_image() {
-                User user = userRepository.save(TestUser.createUser());
-                Emotion emotion = emotionRepository.save(TestEmotion.createEmotion());
-                Diary diary = diaryRepository.save(TestDiary.createTestDiary(user, emotion));
-                imageRepository.save(TestImage.createImage(diary));
+            @Nested
+            @DisplayName("test 파라미터 값이 false일 경우")
+            class if_test_parameter_is_false {
 
-                int page = 0;
-                int size = 5;
-                Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
-                    Pageable.ofSize(size).withPage(page), Direction.DESC, null);
+                @Test
+                @DisplayName("테스트 일기를 제외한 일기 리스트를 반환한다.")
+                @Sql("GetDiariesForMonitorAsPageTest.sql")
+                void return_diary_list_excludes_test_diary() {
+                    User user = userRepository.save(TestUser.createUser());
+                    Emotion emotion = emotionRepository.save(TestEmotion.createEmotion());
+                    Diary diary = diaryRepository.save(TestDiary.createTestDiary(user, emotion));
+                    imageRepository.save(TestImage.createImage(diary));
 
-                assertThat(response.get()
-                    .filter(
-                        diaryResponse -> Objects.equals(diaryResponse.getId(), diary.getDiaryId()))
-                    .findAny()).isEmpty();
+                    int page = 0;
+                    int size = 5;
+                    Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
+                        Pageable.ofSize(size).withPage(page), Direction.DESC, null, false);
+
+                    assertThat(response.get()
+                        .filter(
+                            diaryResponse -> Objects.equals(diaryResponse.getId(),
+                                diary.getDiaryId()))
+                        .findAny()).isEmpty();
+                }
+            }
+
+            @Nested
+            @DisplayName("test 파라미터 값이 true일 경우")
+            class if_test_parameter_is_true {
+
+                @Test
+                @DisplayName("테스트 일기를 포함하여 일기 리스트를 반환한다.")
+                @Sql("GetDiariesForMonitorAsPageTest.sql")
+                void return_diary_list_with_test_diary() {
+                    User user = userRepository.save(TestUser.createUser());
+                    Emotion emotion = emotionRepository.save(TestEmotion.createEmotion());
+                    Diary diary = diaryRepository.save(TestDiary.createTestDiary(user, emotion));
+                    imageRepository.save(TestImage.createImage(diary));
+
+                    int page = 0;
+                    int size = 5;
+                    Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
+                        Pageable.ofSize(size).withPage(page), Direction.DESC, null, true);
+
+                    assertThat(response.get()
+                        .filter(
+                            diaryResponse -> Objects.equals(diaryResponse.getId(),
+                                diary.getDiaryId()))
+                        .findAny()).isPresent();
+                }
             }
         }
 
@@ -291,8 +323,9 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                 int page = 0;
                 int size = 5;
                 Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
-                    Pageable.ofSize(size).withPage(page), Direction.DESC, 1L);
+                    Pageable.ofSize(size).withPage(page), Direction.DESC, 1L, true);
 
+                // 삭제 포함시 5개, 삭제 제외시 3개. 삭제된 일기를 포함하도록 개선될 경우 테스트 통과
                 assertThat(response.getTotalElements()).isEqualTo(5);
                 assertThat(response.getContent().size()).isEqualTo(5);
                 assertThat(response.getTotalPages()).isEqualTo(1);
@@ -307,8 +340,9 @@ class DiaryRepositoryTest extends BaseRepositoryTest {
                 int page = 0;
                 int size = 5;
                 Page<GetDiaryAdminResponse> response = diaryRepository.getDiariesForMonitorAsPage(
-                    Pageable.ofSize(size).withPage(page), Direction.DESC, null);
+                    Pageable.ofSize(size).withPage(page), Direction.DESC, null, true);
 
+                // 삭제 포함시 10개, 삭제 제외시 7개. 삭제된 일기를 포함하도록 개선될 경우 테스트 통과
                 assertThat(response.getTotalElements()).isEqualTo(10);
                 assertThat(response.getContent().size()).isEqualTo(5);
                 assertThat(response.getTotalPages()).isEqualTo(2);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
@@ -2,6 +2,7 @@ package tipitapi.drawmytoday.domain.diary.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
@@ -52,14 +53,14 @@ class AdminDiaryServiceTest {
                 LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), null));
             given(
                 diaryRepository.getDiariesForMonitorAsPage(any(Pageable.class),
-                    any(Direction.class), eq(1L)))
+                    any(Direction.class), eq(1L), anyBoolean()))
                 .willReturn(new PageImpl<>(diaries));
             given(r2PreSignedService.getCustomDomainUrl(any(String.class)))
                 .willReturn("https://test.com");
 
             // when
             Page<GetDiaryAdminResponse> response = adminDiaryService.getDiaries(10, 0,
-                Direction.ASC, 1L);
+                Direction.ASC, 1L, true);
 
             // then
             assertThat(response.getContent().size()).isEqualTo(2);

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryServiceTest.java
@@ -46,11 +46,11 @@ class AdminDiaryServiceTest {
             diaries.add(new GetDiaryAdminResponse(1L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/1.png",
                 "joyful , pink , canvas-textured, Oil Pastel, a crowded subway",
-                LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4"));
+                LocalDateTime.of(2023, 6, 16, 15, 0, 0), LocalDateTime.now(), "4", false));
             diaries.add(new GetDiaryAdminResponse(2L,
                 "https://drawmytoday.s3.ap-northeast-2.amazonaws.com/2021-08-16/2.png",
                 "angry , purple , canvas-textured, Oil Pastel, school",
-                LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), null));
+                LocalDateTime.of(2023, 6, 17, 15, 0, 0), LocalDateTime.now(), null, false));
             given(
                 diaryRepository.getDiariesForMonitorAsPage(any(Pageable.class),
                     any(Direction.class), eq(1L), anyBoolean()))


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [GET] /admin/diaries 관리자 일기 조회 API : 테스트 일기 반환되도록 개선
- 쿼리 파라미터 `test` 를 추가해서, 해당 파라미터 값에 따라 테스트 일기 반환 여부를 판단
- 쿼리 파라미터 `test`는 기본적으로 true로, 기본적으로 테스트 일기를 포함하도록 구현
- controller, service, repository 메서드에 파라미터를 추가하고, 파라미터 값에 따라서 where 절 쿼리를 추가하도록 로직 추가
- `GetAdminDiaryResponse` Response DTO 객체에 해당 일기 객체가 테스트 일기인지 여부를 알 수 있도록, `isTest` 필드 추가

## 관련 이슈

close #269 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
