### PR TITLE
[감정 목록 조회 API] 색깔 프롬프트 값 필드 추가

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
@@ -23,15 +23,19 @@ public class GetActiveEmotionsResponse {
     @Schema(description = "감정 색깔 HEX", requiredMode = RequiredMode.REQUIRED)
     private final String color;
 
-    public static GetActiveEmotionsResponse of(Long id, String name, String color) {
-        return new GetActiveEmotionsResponse(id, name, color);
+    @Schema(description = "감정 색깔 프롬프트값", requiredMode = RequiredMode.REQUIRED)
+    private final String colorPrompt;
+
+    public static GetActiveEmotionsResponse of(Long id, String name, String color,
+        String colorPrompt) {
+        return new GetActiveEmotionsResponse(id, name, color, colorPrompt);
     }
 
     public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions,
         Language language) {
         return emotions.stream()
             .map(e -> GetActiveEmotionsResponse.of(
-                e.getEmotionId(), getEmotionName(language, e), e.getColor()))
+                e.getEmotionId(), getEmotionName(language, e), e.getColor(), e.getColorPrompt()))
             .collect(
                 Collectors.toList());
     }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/EmotionServiceTest.java
@@ -80,6 +80,8 @@ public class EmotionServiceTest {
                 assertThat(emotions.get(0).getId()).isEqualTo(activeEmotion.getEmotionId());
                 assertThat(emotions).extracting(GetActiveEmotionsResponse::getId)
                     .isNotEqualTo(inActiveEmotion.getEmotionId());
+                assertThat(emotions).extracting(GetActiveEmotionsResponse::getColorPrompt)
+                    .contains(activeEmotion.getColorPrompt());
             }
         }
 


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [GET] /emotions/all 감정 목록 조회 API : 색깔 프롬프트 값 필드 추가
- `GetActiveEmotionsResponse` Respones DTO 객체에 필드 추가

## 관련 이슈

close #271 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
