### PR TITLE
프롬프트 환경변수화 및 네거티브 프롬프트 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,6 +91,8 @@ jobs:
                 env:
                     kakao.api.key: ${{ secrets.KAKAO_API_KEY }}
                     kakao.karlo.image_generate_url: ${{ secrets.KARLO_API_URL }}
+                    kakao.karlo.generate_image.negative_prompt: ${{ secrets.KARLO_NEGATIVE_PROMPT }}
+                    kakao.karlo.generate_image.style.default: ${{ secrets.KARLO_DEFAULT_STYLE }}
 
             -   name: Set up JDK 11
                 uses: actions/setup-java@v3

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptTextService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.diary.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -9,6 +10,13 @@ import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 @Transactional(readOnly = true)
 public class PromptTextService {
 
+    private final String defaultStyle;
+
+    public PromptTextService(
+        @Value("${kakao.karlo.generate_image.style.default}") String defaultStyle) {
+        this.defaultStyle = defaultStyle;
+    }
+
     public String createPromptText(Emotion emotion, String keyword) {
         if (!StringUtils.hasText(keyword)) {
             keyword = "portrait";
@@ -16,7 +24,7 @@ public class PromptTextService {
         return promptTextBuilder(
             emotion.getEmotionPrompt(),
             emotion.getColorPrompt(),
-            "Impressionist oil painting",
+            defaultStyle,
             keyword);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/dto/CreateKarloImageRequest.java
@@ -47,11 +47,10 @@ public class CreateKarloImageRequest {
         this.seed = seed;
     }
 
-    public static CreateKarloImageRequest withUrl(String prompt) {
+    public static CreateKarloImageRequest withUrl(String prompt, String negativePrompt) {
         return CreateKarloImageRequest.builder()
             .prompt(prompt)
-            .negativePrompt(
-                "photo, picture, camera, realistic, filim, movie, real, high quality, Scary, cruel, gross, sensational, solid color, not cute")
+            .negativePrompt(negativePrompt)
             .numInferenceSteps(100)
             .guidanceScale(20D)
             .imageFormat("webp")

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestService.java
@@ -26,12 +26,15 @@ class KarloRequestService {
 
     private final RestTemplate restTemplate;
     private final String karloImageCreateUrl;
+    private final String negativePrompt;
     private final HttpHeaders requestHeader;
 
     public KarloRequestService(RestTemplate karloRestTemplate,
-        @Value("${kakao.karlo.image_generate_url}") String karloImageCreateUrl) {
+        @Value("${kakao.karlo.image_generate_url}") String karloImageCreateUrl,
+        @Value("${kakao.karlo.generate_image.negative_prompt}") String negativePrompt) {
         this.restTemplate = karloRestTemplate;
         this.karloImageCreateUrl = karloImageCreateUrl;
+        this.negativePrompt = negativePrompt;
         this.requestHeader = new HttpHeaders() {
             {
                 setContentType(MediaType.APPLICATION_JSON);
@@ -42,7 +45,7 @@ class KarloRequestService {
     byte[] getImageAsUrl(String prompt) throws ImageGeneratorException {
         try {
             HttpEntity<CreateKarloImageRequest> request = getRequest(
-                CreateKarloImageRequest.withUrl(prompt));
+                CreateKarloImageRequest.withUrl(prompt, negativePrompt));
 
             String url = Optional.ofNullable(
                     restTemplate.postForObject(karloImageCreateUrl, request, KarloUrlResponse.class)

--- a/src/main/resources/application-kakao.yml
+++ b/src/main/resources/application-kakao.yml
@@ -3,3 +3,7 @@ kakao:
         key: ${KAKAO_API_KEY}
     karlo:
         image_generate_url: ${KARLO_API_URL}
+        generate_image:
+            negative_prompt: ${KARLO_NEGATIVE_PROMPT}
+            style:
+                default: ${KARLO_DEFAULT_STYLE}

--- a/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/generator/domain/karlo/service/KarloRequestServiceTest.java
@@ -32,12 +32,15 @@ class KarloRequestServiceTest {
 
     String karloImageCreateUrl = "karlo-api-url";
 
+    String negativePrompt = "negative-prompt";
+
     KarloRequestService karloRequestService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        this.karloRequestService = new KarloRequestService(restTemplate, karloImageCreateUrl);
+        this.karloRequestService = new KarloRequestService(restTemplate, karloImageCreateUrl,
+            negativePrompt);
     }
 
     @Nested


### PR DESCRIPTION
# 구현 내용

노션에 추가된 환경변수 작성했습니다. 
또한, Github Actions secret에도 추가했습니다.

## 구현 요약

- 화풍 프롬프트, negative 프롬프트를  환경변수에서 받아오도록 변경
- nude, digital 네거티브 프롬프트 추가
- 실패하는 테스트 추가

## TODO
- 테스트 서버에 환경변수 추가

## 관련 이슈

close #276 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
