### PR TITLE
감정 목록 조회시 영어로 응답 통일

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionController.java
@@ -2,7 +2,6 @@ package tipitapi.drawmytoday.domain.emotion.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -17,9 +16,7 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
@@ -51,12 +48,10 @@ public class EmotionController {
     })
     @GetMapping("/all")
     public ResponseEntity<SuccessResponse<List<GetActiveEmotionsResponse>>> getAllEmotions(
-        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo,
-        @Parameter(description = "반환 언어(ko/en)", in = ParameterIn.QUERY)
-        @RequestParam(name = "lan", required = false, defaultValue = "ko") Language language
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            emotionService.getActiveEmotions(tokenInfo.getUserId(), language)
+            emotionService.getActiveEmotions(tokenInfo.getUserId())
         ).asHttp(HttpStatus.OK);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/dto/GetActiveEmotionsResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 
 @Getter
@@ -31,20 +30,10 @@ public class GetActiveEmotionsResponse {
         return new GetActiveEmotionsResponse(id, name, color, colorPrompt);
     }
 
-    public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions,
-        Language language) {
+    public static List<GetActiveEmotionsResponse> buildWithEmotions(List<Emotion> emotions) {
         return emotions.stream()
             .map(e -> GetActiveEmotionsResponse.of(
-                e.getEmotionId(), getEmotionName(language, e), e.getColor(), e.getColorPrompt()))
-            .collect(
-                Collectors.toList());
-    }
-
-    private static String getEmotionName(Language language, Emotion emotion) {
-        if (Language.ko.equals(language)) {
-            return emotion.getName();
-        } else {
-            return emotion.getEmotionPrompt();
-        }
+                e.getEmotionId(), e.getEmotionPrompt(), e.getColor(), e.getColorPrompt()))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/service/EmotionService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/service/EmotionService.java
@@ -8,7 +8,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tipitapi.drawmytoday.common.cache.CacheConst;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionRequest;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.domain.emotion.dto.GetActiveEmotionsResponse;
@@ -24,11 +23,11 @@ public class EmotionService {
     private final ValidateUserService validateUserService;
 
 
-    @Cacheable(value = CacheConst.ACTIVE_EMOTIONS, key = "#language")
-    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId, Language language) {
+    @Cacheable(CacheConst.ACTIVE_EMOTIONS)
+    public List<GetActiveEmotionsResponse> getActiveEmotions(Long userId) {
         validateUserService.validateUserById(userId);
         return GetActiveEmotionsResponse.buildWithEmotions(
-            emotionRepository.findAllActiveEmotions(), language);
+            emotionRepository.findAllActiveEmotions());
     }
 
     @Transactional

--- a/src/test/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/emotion/controller/EmotionControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.ResultActions;
 import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
 import tipitapi.drawmytoday.common.controller.WithCustomUser;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.domain.emotion.dto.GetActiveEmotionsResponse;
 import tipitapi.drawmytoday.domain.emotion.service.EmotionService;
@@ -65,111 +64,29 @@ class EmotionControllerTest extends ControllerTestSetup {
     @DisplayName("getAllEmotions 메서드는")
     class GetAllEmotions {
 
-        @Nested
-        @DisplayName("lan 쿼리 파라미터가")
-        class LanguageQueryParameter {
+        @Test
+        @DisplayName("영어로 감정 목록을 반환한다.")
+        void en_than_return_english_emotion() throws Exception {
+            //given
+            String language = "en";
+            List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
+                List.of(createEmotion(), createEmotion()));
+            given(emotionService.getActiveEmotions(any(Long.class)))
+                .willReturn(emotionResponses);
 
-            @Test
-            @DisplayName("ko이면 한국어 감정을 반환한다.")
-            void ko_than_return_korean_emotion() throws Exception {
-                //given
-                String language = "ko";
-                List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), Language.ko);
-                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
-                    .willReturn(emotionResponses);
+            //when
+            ResultActions result = mockMvc.perform(get(BASE_URL + "/all"));
 
-                //when
-                ResultActions result = mockMvc.perform(get(BASE_URL + "/all")
-                    .queryParam("language", language));
-
-                //then
-                result.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].id").value(emotionResponses.get(0).getId()))
-                    .andExpect(jsonPath("$.data[0].name").value(emotionResponses.get(0).getName()))
-                    .andExpect(
-                        jsonPath("$.data[0].color").value(emotionResponses.get(0).getColor()))
-                    .andExpect(jsonPath("$.data[1].id").value(emotionResponses.get(1).getId()))
-                    .andExpect(jsonPath("$.data[1].name").value(emotionResponses.get(1).getName()))
-                    .andExpect(
-                        jsonPath("$.data[1].color").value(emotionResponses.get(1).getColor()));
-            }
-
-            @Test
-            @DisplayName("en이면 영어 감정을 반환한다.")
-            void en_than_return_english_emotion() throws Exception {
-                //given
-                String language = "en";
-                List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), Language.en);
-                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
-                    .willReturn(emotionResponses);
-
-                //when
-                ResultActions result = mockMvc.perform(get(BASE_URL + "/all")
-                    .queryParam("language", language));
-
-                //then
-                result.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].id").value(emotionResponses.get(0).getId()))
-                    .andExpect(jsonPath("$.data[0].name").value(emotionResponses.get(0).getName()))
-                    .andExpect(
-                        jsonPath("$.data[0].color").value(emotionResponses.get(0).getColor()))
-                    .andExpect(jsonPath("$.data[1].id").value(emotionResponses.get(1).getId()))
-                    .andExpect(jsonPath("$.data[1].name").value(emotionResponses.get(1).getName()))
-                    .andExpect(
-                        jsonPath("$.data[1].color").value(emotionResponses.get(1).getColor()));
-            }
-
-            @Test
-            @DisplayName("ko, en이 아니면 한국어 감정을 반환한다.")
-            void not_ko_and_en_than_return_korean_emotion() throws Exception {
-                //given
-                String language = "hello";
-                List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), Language.ko);
-                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
-                    .willReturn(emotionResponses);
-
-                //when
-                ResultActions result = mockMvc.perform(get(BASE_URL + "/all")
-                    .queryParam("language", language));
-
-                //then
-                result.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].id").value(emotionResponses.get(0).getId()))
-                    .andExpect(jsonPath("$.data[0].name").value(emotionResponses.get(0).getName()))
-                    .andExpect(
-                        jsonPath("$.data[0].color").value(emotionResponses.get(0).getColor()))
-                    .andExpect(jsonPath("$.data[1].id").value(emotionResponses.get(1).getId()))
-                    .andExpect(jsonPath("$.data[1].name").value(emotionResponses.get(1).getName()))
-                    .andExpect(
-                        jsonPath("$.data[1].color").value(emotionResponses.get(1).getColor()));
-            }
-
-            @Test
-            @DisplayName("쿼리 파라미터가 없으면 한국어 감정을 반환한다.")
-            void not_query_parameter_than_return_korean_emotion() throws Exception {
-                //given
-                List<GetActiveEmotionsResponse> emotionResponses = GetActiveEmotionsResponse.buildWithEmotions(
-                    List.of(createEmotion(), createEmotion()), Language.ko);
-                given(emotionService.getActiveEmotions(any(Long.class), any(Language.class)))
-                    .willReturn(emotionResponses);
-
-                //when
-                ResultActions result = mockMvc.perform(get(BASE_URL + "/all"));
-
-                //then
-                result.andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].id").value(emotionResponses.get(0).getId()))
-                    .andExpect(jsonPath("$.data[0].name").value(emotionResponses.get(0).getName()))
-                    .andExpect(
-                        jsonPath("$.data[0].color").value(emotionResponses.get(0).getColor()))
-                    .andExpect(jsonPath("$.data[1].id").value(emotionResponses.get(1).getId()))
-                    .andExpect(jsonPath("$.data[1].name").value(emotionResponses.get(1).getName()))
-                    .andExpect(
-                        jsonPath("$.data[1].color").value(emotionResponses.get(1).getColor()));
-            }
+            //then
+            result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id").value(emotionResponses.get(0).getId()))
+                .andExpect(jsonPath("$.data[0].name").value(emotionResponses.get(0).getName()))
+                .andExpect(
+                    jsonPath("$.data[0].color").value(emotionResponses.get(0).getColor()))
+                .andExpect(jsonPath("$.data[1].id").value(emotionResponses.get(1).getId()))
+                .andExpect(jsonPath("$.data[1].name").value(emotionResponses.get(1).getName()))
+                .andExpect(
+                    jsonPath("$.data[1].color").value(emotionResponses.get(1).getColor()));
         }
     }
 

--- a/src/test/java/tipitapi/drawmytoday/domain/emotion/repository/EmotionRepositoryTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/emotion/repository/EmotionRepositoryTest.java
@@ -1,4 +1,4 @@
-package tipitapi.drawmytoday.domain.diary.repository;
+package tipitapi.drawmytoday.domain.emotion.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,7 +15,6 @@ import tipitapi.drawmytoday.common.BaseRepositoryTest;
 import tipitapi.drawmytoday.common.config.QuerydslConfig;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
-import tipitapi.drawmytoday.domain.emotion.repository.EmotionRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)

--- a/src/test/java/tipitapi/drawmytoday/domain/emotion/service/EmotionServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/emotion/service/EmotionServiceTest.java
@@ -1,4 +1,4 @@
-package tipitapi.drawmytoday.domain.diary.service;
+package tipitapi.drawmytoday.domain.emotion.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,14 +18,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionRequest;
 import tipitapi.drawmytoday.domain.emotion.dto.CreateEmotionResponse;
 import tipitapi.drawmytoday.domain.emotion.dto.GetActiveEmotionsResponse;
 import tipitapi.drawmytoday.domain.emotion.repository.EmotionRepository;
-import tipitapi.drawmytoday.domain.emotion.service.EmotionService;
 import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.exception.UserNotFoundException;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
@@ -56,7 +54,7 @@ public class EmotionServiceTest {
                 given(validateUserService.validateUserById(1L)).willThrow(
                     new UserNotFoundException());
 
-                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L, Language.ko))
+                assertThatThrownBy(() -> emotionService.getActiveEmotions(1L))
                     .isInstanceOf(UserNotFoundException.class);
             }
         }
@@ -75,7 +73,7 @@ public class EmotionServiceTest {
                 given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
 
                 List<GetActiveEmotionsResponse> emotions =
-                    emotionService.getActiveEmotions(1L, Language.ko);
+                    emotionService.getActiveEmotions(1L);
 
                 assertThat(emotions.get(0).getId()).isEqualTo(activeEmotion.getEmotionId());
                 assertThat(emotions).extracting(GetActiveEmotionsResponse::getId)
@@ -98,7 +96,7 @@ public class EmotionServiceTest {
                 given(emotionRepository.findAllActiveEmotions()).willReturn(List.of(activeEmotion));
 
                 List<GetActiveEmotionsResponse> emotions =
-                    emotionService.getActiveEmotions(1L, Language.en);
+                    emotionService.getActiveEmotions(1L);
 
                 assertThat(emotions.get(0).getName()).isEqualTo(activeEmotion.getEmotionPrompt());
             }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [GET] /emotions/all 감정 목록 조회 API : 응답 언어를 영어로 통일
- 기존에는 영어 / 한국어로 응답을 제공했으나, 이를 영어로 통일함
- 쿼리 파라미터 적용 로직 삭제
- 메서드 파라미터 및 로직, 테스트 삭제

### emotion 도메인 테스트 코드 이동
- emotionService, emotionRepository 에 대한 테스트코드가 diary 패키지 내에 위치해있어, emotion 패키지로 이동함



## 관련 이슈

close #278 
## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
