### PR TITLE
일기 조회 API의 응답을 영어로 통일

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/controller/DiaryController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.resolver.AuthUser;
 import tipitapi.drawmytoday.common.response.SuccessResponse;
 import tipitapi.drawmytoday.common.security.jwt.JwtTokenInfo;
@@ -64,12 +63,10 @@ public class DiaryController {
     @GetMapping("/{id}")
     public ResponseEntity<SuccessResponse<GetDiaryResponse>> getDiary(
         @Parameter(description = "일기 id", in = ParameterIn.PATH) @PathVariable("id") Long diaryId,
-        @Parameter(description = "감정 반환 언어(ko/en)", in = ParameterIn.QUERY)
-        @RequestParam(name = "lan", required = false, defaultValue = "ko") Language language
-        , @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
+        @AuthUser @Parameter(hidden = true) JwtTokenInfo tokenInfo
     ) {
         return SuccessResponse.of(
-            diaryService.getDiary(tokenInfo.getUserId(), diaryId, language)
+            diaryService.getDiary(tokenInfo.getUserId(), diaryId)
         ).asHttp(HttpStatus.OK);
     }
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/DiaryService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.entity.BaseEntity;
 import tipitapi.drawmytoday.common.utils.DateUtils;
 import tipitapi.drawmytoday.common.utils.Encryptor;
@@ -45,7 +44,7 @@ public class DiaryService {
     private final ValidateDiaryService validateDiaryService;
     private final ValidateTicketService validateTicketService;
 
-    public GetDiaryResponse getDiary(Long userId, Long diaryId, Language language) {
+    public GetDiaryResponse getDiary(Long userId, Long diaryId) {
         User user = validateUserService.validateUserById(userId);
 
         Diary diary = validateDiaryService.validateDiaryById(diaryId, user);
@@ -64,7 +63,7 @@ public class DiaryService {
                     r2PreSignedService.getCustomDomainUrl(image.getImageUrl())))
             .collect(Collectors.toList());
 
-        String emotionText = diary.getEmotion().getEmotionText(language);
+        String emotionText = diary.getEmotion().getEmotionPrompt();
 
         String promptText = promptService.getPromptByDiaryId(diaryId)
             .map(Prompt::getPromptText).orElse(null);

--- a/src/main/java/tipitapi/drawmytoday/domain/emotion/domain/Emotion.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/emotion/domain/Emotion.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.entity.BaseEntity;
 
 @Getter
@@ -53,9 +52,5 @@ public class Emotion extends BaseEntity {
     public static Emotion create(String name, String color, boolean isActive, String emotionPrompt,
         String colorPrompt) {
         return new Emotion(name, color, isActive, emotionPrompt, colorPrompt);
-    }
-
-    public String getEmotionText(Language language) {
-        return language == Language.ko ? name : emotionPrompt;
     }
 }

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/controller/DiaryControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.ResultActions;
 import tipitapi.drawmytoday.common.controller.ControllerTestSetup;
 import tipitapi.drawmytoday.common.controller.WithCustomUser;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.testdata.TestDiary;
 import tipitapi.drawmytoday.common.testdata.TestEmotion;
 import tipitapi.drawmytoday.common.testdata.TestUser;
@@ -76,8 +75,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 long diaryId = 1L;
                 User user = TestUser.createUser();
                 Emotion emotion = TestEmotion.createEmotion();
-                Language language = Language.ko;
-                String emotionText = emotion.getEmotionText(language);
+                String emotionText = emotion.getEmotionPrompt();
                 Diary diary = TestDiary.createDiaryWithIdAndCreatedAt(
                     diaryId, LocalDateTime.now(), user, emotion);
                 String imageUrl = "imageUrl";
@@ -86,7 +84,7 @@ class DiaryControllerTest extends ControllerTestSetup {
                 String promptText = "promptText";
                 GetDiaryResponse getDiaryResponse = GetDiaryResponse.of(diary, imageUrl,
                     imageList, emotionText, promptText);
-                given(diaryService.getDiary(REQUEST_USER_ID, diaryId, language)).willReturn(
+                given(diaryService.getDiary(REQUEST_USER_ID, diaryId)).willReturn(
                     getDiaryResponse);
 
                 // when

--- a/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/tipitapi/drawmytoday/domain/diary/service/DiaryServiceTest.java
@@ -29,7 +29,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import tipitapi.drawmytoday.common.converter.Language;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
@@ -87,9 +86,9 @@ class DiaryServiceTest {
             @DisplayName("일기를 반환한다.")
             void it_returns_diary() {
                 User user = createUserWithId(1L);
-                Diary diary = createDiaryWithId(1L, user, createEmotion());
+                Emotion emotion = createEmotion();
+                Diary diary = createDiaryWithId(1L, user, emotion);
                 List<Image> images = List.of(createImage(diary));
-                Language language = Language.ko;
 
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(validateDiaryService.validateDiaryById(1L, user)).willReturn(diary);
@@ -99,55 +98,10 @@ class DiaryServiceTest {
                 given(encryptor.decrypt(diary.getNotes())).willReturn("decrypted notes");
                 given(promptService.getPromptByDiaryId(anyLong())).willReturn(Optional.empty());
 
-                GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L, language);
+                GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L);
 
                 assertThat(getDiaryResponse.getId()).isEqualTo(diary.getDiaryId());
-            }
-
-            @Test
-            @DisplayName("language가 en일 경우 emotion에 emotioPrompt를 반환한다.")
-            void if_lan_en_then_return_emotionPrompt() {
-                User user = createUserWithId(1L);
-                Emotion emotion = createEmotion();
-                Diary diary = createDiaryWithId(1L, user, emotion);
-                List<Image> images = List.of(createImage(diary));
-
-                Language language = Language.en;
-
-                given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(validateDiaryService.validateDiaryById(1L, user)).willReturn(diary);
-                given(imageService.getLatestImages(diary)).willReturn(images);
-                given(r2PreSignedService.getCustomDomainUrl(any(String.class)))
-                    .willReturn("https://test.com");
-                given(encryptor.decrypt(diary.getNotes())).willReturn("decrypted notes");
-                given(promptService.getPromptByDiaryId(anyLong())).willReturn(Optional.empty());
-
-                GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L, language);
-
                 assertThat(getDiaryResponse.getEmotion()).isEqualTo(emotion.getEmotionPrompt());
-            }
-
-            @Test
-            @DisplayName("language가 ko일 경우 emotion에 name을 반환한다.")
-            void if_lan_ko_then_return_name() {
-                User user = createUserWithId(1L);
-                Emotion emotion = createEmotion();
-                Diary diary = createDiaryWithId(1L, user, emotion);
-                List<Image> images = List.of(createImage(diary));
-
-                Language language = Language.ko;
-
-                given(validateUserService.validateUserById(1L)).willReturn(user);
-                given(validateDiaryService.validateDiaryById(1L, user)).willReturn(diary);
-                given(imageService.getLatestImages(diary)).willReturn(images);
-                given(r2PreSignedService.getCustomDomainUrl(any(String.class)))
-                    .willReturn("https://test.com");
-                given(encryptor.decrypt(diary.getNotes())).willReturn("decrypted notes");
-                given(promptService.getPromptByDiaryId(anyLong())).willReturn(Optional.empty());
-
-                GetDiaryResponse getDiaryResponse = diaryService.getDiary(1L, 1L, language);
-
-                assertThat(getDiaryResponse.getEmotion()).isEqualTo(emotion.getName());
             }
         }
 
@@ -159,12 +113,11 @@ class DiaryServiceTest {
             @DisplayName("DiaryNotFoundException 예외를 발생시킨다.")
             void it_throws_DiaryNotFoundException() {
                 User user = createUser();
-                Language language = Language.ko;
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(validateDiaryService.validateDiaryById(1L, user)).willThrow(
                     DiaryNotFoundException.class);
 
-                assertThatThrownBy(() -> diaryService.getDiary(1L, 1L, language))
+                assertThatThrownBy(() -> diaryService.getDiary(1L, 1L))
                     .isInstanceOf(DiaryNotFoundException.class);
             }
         }
@@ -177,12 +130,11 @@ class DiaryServiceTest {
             @DisplayName("NotOwnerOfDiaryException 예외를 발생시킨다.")
             void it_throws_NotOwnerOfDiaryException() {
                 User user = createUserWithId(1L);
-                Language language = Language.ko;
                 given(validateUserService.validateUserById(1L)).willReturn(user);
                 given(validateDiaryService.validateDiaryById(1L, user))
                     .willThrow(NotOwnerOfDiaryException.class);
 
-                assertThatThrownBy(() -> diaryService.getDiary(1L, 1L, language))
+                assertThatThrownBy(() -> diaryService.getDiary(1L, 1L))
                     .isInstanceOf(NotOwnerOfDiaryException.class);
             }
         }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

### [GET] /diary/{id} 일기 조회 API : 응답 언어를 영어로 통일

- 기존에는 영어 / 한국어로 응답을 제공했으나, 이를 영어로 통일함
- 쿼리 파라미터 적용 로직 삭제
- 메서드 파라미터 및 로직, 테스트 삭제


## 관련 이슈

close #280 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
