### PR TITLE
jackson-databind와 다른 의존성간 버전 충돌 문제 및 애플 소셜탈퇴 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     // logback 설정
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
 
     //	스프링 시큐리티, jwt 설정
     implementation 'org.springframework.boot:spring-boot-starter-security'


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- jackson-databind와 jackson-annotations의 버전 불일치로 인한 에러 해결
  - 자세한 내용 [참조](https://twofootdog.tistory.com/105)
- 애플 소셜탈퇴시 ErrorResponse가 반환될 때만 실패하도록 변경

## 관련 이슈

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
