### PR TITLE
애플 소셜로그인 회원탈퇴 실패 이슈

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/exception/BusinessException.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/BusinessException.java
@@ -1,13 +1,16 @@
 package tipitapi.drawmytoday.common.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 
     public BusinessException(ErrorCode errorCode, Throwable throwable) {
         super(errorCode.getMessage(), throwable);

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -78,7 +78,10 @@ public enum ErrorCode {
     REST_CLIENT_FAILED(500, "R001", "외부로의 REST 통신에 실패하였습니다."),
 
     // Ticket
-    VALID_TICKET_NOT_EXISTS(404, "T001", "유효한 티켓이 존재하지 않습니다.");
+    VALID_TICKET_NOT_EXISTS(404, "T001", "유효한 티켓이 존재하지 않습니다."),
+
+    // Apple
+    APPLE_EMAIL_NOT_FOUND(400, "A001", "애플 소셜서버로부터 이메일을 받지 못했습니다.");
 
 
     private final int status;

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -7,11 +7,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Base64;
-import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,7 @@ import tipitapi.drawmytoday.domain.user.domain.User;
 import tipitapi.drawmytoday.domain.user.service.UserService;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -47,8 +49,6 @@ public class AppleOAuthService {
     private final UserService userService;
     private final AuthRepository authRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final List<String> revokeFailedCodes = List.of("invalid_request", "invalid_client",
-        "invalid_grant", "unauthorized_client", "unsupported_grant_type", "invalid_scope");
 
     @Transactional
     public ResponseJwtToken login(HttpServletRequest request, RequestAppleLogin requestAppleLogin) {
@@ -71,11 +71,6 @@ public class AppleOAuthService {
         return ResponseJwtToken.of(jwtAccessToken, jwtRefreshToken);
     }
 
-    /**
-     * revoke token시 error response 명세
-     *
-     * @see "https://developer.apple.com/documentation/sign_in_with_apple/errorresponse"
-     */
     @Transactional
     public void deleteAccount(User user) {
         Auth auth = authRepository.findByUser(user).orElseThrow(OAuthNotFoundException::new);
@@ -92,15 +87,13 @@ public class AppleOAuthService {
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
         String url = properties.getDeleteAccountUrl();
-        String response = restTemplate.postForObject(url, request, String.class);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
 
-        if (response != null) {
-            revokeFailedCodes.stream()
-                .filter(response::contains)
-                .findAny()
-                .ifPresent(code -> {
-                    throw new BusinessException(OAUTH_SERVER_FAILED, new Throwable(response));
-                });
+        log.info("userId: {} 애플 회원탈퇴 response 정보: status code: {}, body: {}",
+            user.getUserId(), response.getStatusCode(), response.getBody());
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new BusinessException(OAUTH_SERVER_FAILED, new Throwable(response.getBody()));
         }
 
         user.deleteUser();

--- a/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/oauth/service/AppleOAuthService.java
@@ -1,5 +1,6 @@
 package tipitapi.drawmytoday.domain.oauth.service;
 
+import static tipitapi.drawmytoday.common.exception.ErrorCode.APPLE_EMAIL_NOT_FOUND;
 import static tipitapi.drawmytoday.common.exception.ErrorCode.OAUTH_SERVER_FAILED;
 import static tipitapi.drawmytoday.common.exception.ErrorCode.PARSING_ERROR;
 
@@ -55,6 +56,10 @@ public class AppleOAuthService {
         OAuthAccessToken oAuthAccessToken = getAccessToken(request);
         AppleIdToken appleIdToken = getAppleIdToken(requestAppleLogin.getIdToken());
 
+        if (appleIdToken.getEmail() == null) {
+            throw new BusinessException(APPLE_EMAIL_NOT_FOUND);
+        }
+
         User user = validateUserService.validateRegisteredUserByEmail(
             appleIdToken.getEmail(), SocialCode.APPLE);
 
@@ -88,9 +93,6 @@ public class AppleOAuthService {
 
         String url = properties.getDeleteAccountUrl();
         ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
-
-        log.info("userId: {} 애플 회원탈퇴 response 정보: status code: {}, body: {}",
-            user.getUserId(), response.getStatusCode(), response.getBody());
 
         if (response.getStatusCode() != HttpStatus.OK) {
             throw new BusinessException(OAUTH_SERVER_FAILED, new Throwable(response.getBody()));


### PR DESCRIPTION
# 구현 내용
### 상황
애플 소셜로그인 회원탈퇴 시도 -> 200 응답 성공(다만, 애플 계정에서 애플로 로그인된 앱을 확인하면 정상적으로 탈퇴되지 않은 것을 볼 수 있음) -> 애플로그인 재시도 -> 프론트로부터 받은 idToken을 파싱해도 이메일을 얻을 수 없음(왜..?) -> 이메일이 없기에 회원가입 실패

### 시도
Q. refresh token으로 해당 토큰이 만료됐는지 확인할 수 있음. 만약 회원탈퇴가 정상적으로 처리되지 않았다면 토큰이 만료되지 않았다고 뜨지 않을까?
A. 회원 탈퇴 시도 시 200 응답은 떳지만 회원탈퇴가 안된 상황에서도 refresh token은 만료됨(애플 소셜서버를 어떻게 만든거야..)

### 결론
백단은 애플 소셜로그인 시 이메일이 없다면 이메일이 없다는 에러를 반환하도록 하고, 프론트단에서 유저에게 직접 계정에 들어가 회원탈퇴하도록 유도하는 방향이 최선일거 같습니다.

## 구현 요약

- businessException에 message를 추가하도록 변경(에러 로그시 null값이 뜨기 때문)
- 애플 소셜로그인시 이메일을 못 받으면 에러를 던지도록 수정

## 관련 이슈

close #291 

## 구현 내용

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
