### PR TITLE
특정 날짜 일기 존재 여부 조회시 2월 29일을 정상적인 값으로 받지 않는 이슈 해결

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
+++ b/src/main/java/tipitapi/drawmytoday/common/utils/DateUtils.java
@@ -41,7 +41,7 @@ public class DateUtils {
 
     private static int getMaxDay(int month) {
         if (month == 2) {
-            return 28;
+            return 29;
         }
         if (Stream.of(1, 3, 5, 7, 8, 10, 12)
             .anyMatch(m -> m == month)) {


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 급하게 운영 서버에 배포하느라 무중단 배포 작업본과 함께 main 브랜치에 머지했습니다. 해당 PR 머지되면 배포 PR 만들겠습니다!(실제 배포 actions는 취소하겠습니다)

## 관련 이슈

close # (issue)

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
