### PR TITLE
일기 재생성시 기존 GPT 요청 정보를 포함하도록 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,5 +92,6 @@ jobs:
                         add_env_var "RDS_USERNAME" "${{ secrets.RDS_USERNAME }}"
                         add_env_var "RDS_PASSWORD" "${{ secrets.RDS_PASSWORD }}"
                         add_env_var "GPT_CHAT_COMPLETIONS_PROMPT" "${{ secrets.GPT_CHAT_COMPLETIONS_PROMPT }}"
+                        add_env_var "GPT_CHAT_COMPLETIONS_REGENERATE_PROMPT" "${{ secrets.GPT_CHAT_COMPLETIONS_REGENERATE_PROMPT }}"
                         
                         ./deploy.sh

--- a/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
+++ b/src/main/java/tipitapi/drawmytoday/common/exception/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     EMOTION_NOT_FOUND(404, "E001", "감정을 찾을 수 없습니다."),
 
     // Prompt
-    PROMPT_NOT_EXIST(500, "P001", "프롬프트가 존재하지 않습니다."),
+    PROMPT_NOT_FOUND(404, "P001", "프롬프트를 찾을 수 없습니다."),
 
     // R2
     R2_SERVICE_ERROR(500, "R001", "R2Exception 에러가 발생하였습니다."),

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
@@ -1,6 +1,5 @@
 package tipitapi.drawmytoday.domain.diary.domain;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -18,7 +17,6 @@ public class PromptGeneratorResult {
     private PromptGeneratorType promptGeneratorType;
     @Type(type = "text")
     private String promptGeneratorContent;
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private PromptGeneratorResult(PromptGeneratorType promptGeneratorType,
         String promptGeneratorContent) {
@@ -31,7 +29,7 @@ public class PromptGeneratorResult {
     }
 
     public static PromptGeneratorResult createNoUse() {
-        return new PromptGeneratorResult(PromptGeneratorType.NONE, "");
+        return new PromptGeneratorResult(PromptGeneratorType.NONE, null);
     }
 
     public PromptGeneratorType getPromptGeneratorType() {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/exception/PromptNotFoundException.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/exception/PromptNotFoundException.java
@@ -3,9 +3,9 @@ package tipitapi.drawmytoday.domain.diary.exception;
 import tipitapi.drawmytoday.common.exception.BusinessException;
 import tipitapi.drawmytoday.common.exception.ErrorCode;
 
-public class PromptNotExistException extends BusinessException {
+public class PromptNotFoundException extends BusinessException {
 
-    public PromptNotExistException() {
-        super(ErrorCode.PROMPT_NOT_EXIST);
+    public PromptNotFoundException() {
+        super(ErrorCode.PROMPT_NOT_FOUND);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/PromptRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/PromptRepository.java
@@ -1,12 +1,12 @@
 package tipitapi.drawmytoday.domain.diary.repository;
 
-import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
 
 public interface PromptRepository extends JpaRepository<Prompt, Long> {
 
-    @Query("SELECT p FROM Image i JOIN i.prompt p WHERE i.imageId = :imageId AND p.isSuccess = true")
-    List<Prompt> findAllSuccessPromptByImageId(Long imageId);
+    @Query("SELECT p FROM Image i JOIN i.prompt p WHERE i.imageId = :imageId")
+    Optional<Prompt> findByImageId(Long imageId);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
@@ -111,7 +111,9 @@ public class CreateDiaryService {
         Prompt prompt = validatePromptService.validatePromptByImageId(
             diary.getSelectedImage().getImageId());
 
-        if (prompt.getPromptGeneratorResult().getPromptGeneratorContent() == null) {
+        String promptGeneratorContent = prompt.getPromptGeneratorResult()
+            .getPromptGeneratorContent();
+        if (promptGeneratorContent == null || promptGeneratorContent.isBlank()) {
             prompt = promptTextService.generatePromptUsingGpt(emotion, diaryNote);
         } else {
             prompt = promptTextService.regeneratePromptUsingGpt(emotion, diaryNote, prompt);

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
@@ -13,7 +13,6 @@ import tipitapi.drawmytoday.domain.diary.domain.Prompt;
 import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryRequest;
 import tipitapi.drawmytoday.domain.diary.dto.CreateDiaryResponse;
 import tipitapi.drawmytoday.domain.diary.dto.CreateTestDiaryRequest;
-import tipitapi.drawmytoday.domain.diary.exception.PromptNotExistException;
 import tipitapi.drawmytoday.domain.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.domain.emotion.domain.Emotion;
 import tipitapi.drawmytoday.domain.emotion.service.ValidateEmotionService;
@@ -34,6 +33,7 @@ public class CreateDiaryService {
     private final ValidateEmotionService validateEmotionService;
     private final ValidateDiaryService validateDiaryService;
     private final ValidateTicketService validateTicketService;
+    private final ValidatePromptService validatePromptService;
     private final ImageGeneratorService karloService;
     private final PromptService promptService;
     private final Encryptor encryptor;
@@ -115,8 +115,7 @@ public class CreateDiaryService {
     private void regenerateDiaryImageWithPreviousPrompt(Diary diary)
         throws ImageGeneratorException {
         Long imageId = diary.getSelectedImage().getImageId();
-        Prompt prompt = promptService.getPromptByImageId(imageId)
-            .orElseThrow(PromptNotExistException::new);
+        Prompt prompt = validatePromptService.validatePromptByImageId(imageId);
 
         byte[] image = karloService.generateImage(prompt);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/CreateDiaryService.java
@@ -110,7 +110,12 @@ public class CreateDiaryService {
             diary.getEmotion().getEmotionId());
         Prompt prompt = validatePromptService.validatePromptByImageId(
             diary.getSelectedImage().getImageId());
-        prompt = promptTextService.regeneratePromptUsingGpt(emotion, diaryNote, prompt);
+
+        if (prompt.getPromptGeneratorResult().getPromptGeneratorContent() == null) {
+            prompt = promptTextService.generatePromptUsingGpt(emotion, diaryNote);
+        } else {
+            prompt = promptTextService.regeneratePromptUsingGpt(emotion, diaryNote, prompt);
+        }
 
         byte[] image = karloService.generateImage(prompt);
 

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptService.java
@@ -28,8 +28,7 @@ public class PromptService {
     }
 
     public Optional<Prompt> getPromptByImageId(Long imageId) {
-        return promptRepository.findAllSuccessPromptByImageId(imageId)
-            .stream().findFirst();
+        return promptRepository.findByImageId(imageId);
     }
 
     public Prompt savePrompt(Prompt prompt) {

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/ValidatePromptService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/ValidatePromptService.java
@@ -1,0 +1,21 @@
+package tipitapi.drawmytoday.domain.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.exception.PromptNotFoundException;
+import tipitapi.drawmytoday.domain.diary.repository.PromptRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ValidatePromptService {
+
+    private final PromptRepository promptRepository;
+
+    public Prompt validatePromptByImageId(Long imageId) {
+        return promptRepository.findByImageId(imageId)
+            .orElseThrow(PromptNotFoundException::new);
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/dto/GptChatCompletionsRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/dto/GptChatCompletionsRequest.java
@@ -18,6 +18,11 @@ public class GptChatCompletionsRequest {
     private final String model;
     private final List<Message> messages;
 
+    public GptChatCompletionsRequest() {
+        this.model = "gpt-3.5-turbo";
+        this.messages = new ArrayList<>();
+    }
+
     private GptChatCompletionsRequest(String gptChatCompletionsPrompt) {
         this.model = "gpt-3.5-turbo";
         List<Message> messages = new ArrayList<>();
@@ -32,7 +37,19 @@ public class GptChatCompletionsRequest {
         return request;
     }
 
+    public static GptChatCompletionsRequest createRegenerateMessage(
+        List<Message> previousGptMessages, String gptRegeneratePrompt) {
+        GptChatCompletionsRequest request = new GptChatCompletionsRequest();
+        request.addPreviousGptMessages(previousGptMessages);
+        request.addUserMessage(gptRegeneratePrompt);
+        return request;
+    }
+
     private void addUserMessage(String userMessage) {
         this.messages.add(new Message(ChatCompletionsRole.user, userMessage));
+    }
+
+    private void addPreviousGptMessages(List<Message> previousGptMessages) {
+        this.messages.addAll(previousGptMessages);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
@@ -1,9 +1,12 @@
 package tipitapi.drawmytoday.domain.generator.service;
 
 import java.util.List;
+import tipitapi.drawmytoday.domain.diary.domain.Prompt;
 import tipitapi.drawmytoday.domain.generator.domain.TextGeneratorContent;
 
 public interface TextGeneratorService {
 
     List<? extends TextGeneratorContent> generatePrompt(String keyword);
+
+    List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt);
 }

--- a/src/main/resources/application-openai.yml
+++ b/src/main/resources/application-openai.yml
@@ -5,3 +5,4 @@ openai:
         url: ${DALLE_API_URL}
     gpt:
         chat_completions_prompt: ${GPT_CHAT_COMPLETIONS_PROMPT}
+        chat_completions_regenerate_prompt: ${GPT_CHAT_COMPLETIONS_REGENERATE_PROMPT}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 일기 재생성시 기존 gpt 히스토리가 없다면 gpt 히스토리 없이 gpt 호출하도록 구현
- 일기 재생성시 기존 gpt 히스토리가 있다면 `gpt history + gpt regenerate prompt(형원's prompt) + 번역된 일기`로 호출하도록 구현

## 관련 이슈

close #306

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
