### PR TITLE
일기 프롬프트 생성을 위해 호출한 GPT History를 모든 일기가 갖도록 변경

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/common/config/TransactionTemplateConfig.java
+++ b/src/main/java/tipitapi/drawmytoday/common/config/TransactionTemplateConfig.java
@@ -1,0 +1,26 @@
+package tipitapi.drawmytoday.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionTemplateConfig {
+
+    @Bean
+    public TransactionTemplate writeTransactionTemplate(
+        PlatformTransactionManager transactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(false);
+        return transactionTemplate;
+    }
+
+    @Bean
+    public TransactionTemplate readTransactionTemplate(
+        PlatformTransactionManager transactionManager) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        return transactionTemplate;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
@@ -59,5 +60,17 @@ public class AdminController {
             adminService.getDiaries(tokenInfo.getUserId(), size, page, direction, emotionId,
                 withTest)
         ).asHttp(HttpStatus.OK);
+    }
+
+    @Operation(summary = "GPT Generator Content 추가")
+    @GetMapping("/add-gpt-generator-content")
+    public ResponseEntity<Integer> addGptGeneratorContent(
+        @AuthUser JwtTokenInfo jwtTokenInfo,
+        @RequestParam(value = "reputation", required = false, defaultValue = "1") Long reputation
+    ) {
+        int added = LongStream.range(0, reputation).
+            mapToObj(i -> adminService.addGptGeneratorContent(jwtTokenInfo.getUserId())).
+            reduce(0, Integer::sum);
+        return ResponseEntity.ok(added);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/controller/AdminController.java
@@ -68,9 +68,9 @@ public class AdminController {
         @AuthUser JwtTokenInfo jwtTokenInfo,
         @RequestParam(value = "reputation", required = false, defaultValue = "1") Long reputation
     ) {
-        int added = LongStream.range(0, reputation).
+        int addedCount = LongStream.range(0, reputation).
             mapToObj(i -> adminService.addGptGeneratorContent(jwtTokenInfo.getUserId())).
             reduce(0, Integer::sum);
-        return ResponseEntity.ok(added);
+        return ResponseEntity.ok(addedCount);
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryNoteAndPromptResponse.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/dto/GetDiaryNoteAndPromptResponse.java
@@ -1,0 +1,28 @@
+package tipitapi.drawmytoday.domain.admin.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class GetDiaryNoteAndPromptResponse {
+
+    private final Long promptId;
+    private String notes;
+    private final String prompt;
+
+    @QueryProjection
+    public GetDiaryNoteAndPromptResponse(Long promptId, String notes, String prompt) {
+        this.promptId = promptId;
+        this.notes = notes;
+        this.prompt = prompt;
+    }
+
+    public void updateNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public String getGptPrompt() {
+        String[] promptTexts = prompt.split("Impressionist oil painting,");
+        return promptTexts[promptTexts.length - 1].trim();
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
@@ -1,25 +1,104 @@
 package tipitapi.drawmytoday.domain.admin.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.domain.admin.dto.GetDiaryNoteAndPromptResponse;
+import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.repository.PromptRepository;
 import tipitapi.drawmytoday.domain.diary.service.AdminDiaryService;
+import tipitapi.drawmytoday.domain.generator.api.gpt.domain.ChatCompletionsRole;
+import tipitapi.drawmytoday.domain.generator.api.gpt.domain.Message;
+import tipitapi.drawmytoday.domain.generator.api.gpt.dto.GptChatCompletionsRequest;
+import tipitapi.drawmytoday.domain.generator.service.TranslateTextService;
 import tipitapi.drawmytoday.domain.user.service.ValidateUserService;
 
+@Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AdminService {
 
     private final ValidateUserService validateUserService;
     private final AdminDiaryService adminDiaryService;
+    private final TranslateTextService translateTextService;
+    private final TransactionTemplate writeTransactionTemplate;
+    private final PromptRepository promptRepository;
+    private final ObjectMapper objectMapper;
+    @Value("${openai.gpt.chat_completions_prompt}")
+    private String gptChatCompletionsPrompt;
 
+    @Transactional(readOnly = true)
     public Page<GetDiaryAdminResponse> getDiaries(Long userId, int size, int page,
         Direction direction, Long emotionId, boolean withTest) {
         validateUserService.validateAdminUserById(userId);
         return adminDiaryService.getDiaries(size, page, direction, emotionId, withTest);
+    }
+
+    public int addGptGeneratorContent(Long userId) {
+        validateUserService.validateAdminUserById(userId);
+        List<GetDiaryNoteAndPromptResponse> responses = adminDiaryService.getDiaryNoteAndPrompt();
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(responses.size());
+        for (int i = 0; i < responses.size(); i++) {
+            GetDiaryNoteAndPromptResponse response = responses.get(i);
+            int finalI = i;
+            executor.execute(() -> {
+                try {
+                    String translatedNotes = translateTextService.translateAutoToEnglish(
+                        response.getNotes());
+                    response.updateNotes(translatedNotes);
+                } catch (Exception e) {
+                    log.error("번역 API 예외가 발생했습니다.", e);
+                    responses.remove(finalI);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("작업이 중단되었습니다.", e);
+            throw new RuntimeException(e);
+        }
+
+        executor.shutdown();
+
+        if (responses.isEmpty()) {
+            throw new RuntimeException("번역할 데이터가 없거나 모두 실패했습니다.");
+        }
+
+        writeTransactionTemplate.executeWithoutResult(status -> {
+            for (GetDiaryNoteAndPromptResponse response : responses) {
+                Prompt prompt = promptRepository.findById(response.getPromptId()).get();
+                List<Message> messages = GptChatCompletionsRequest.createFirstMessage(
+                        gptChatCompletionsPrompt, response.getNotes())
+                    .getMessages();
+                messages.add(new Message(ChatCompletionsRole.assistant, response.getGptPrompt()));
+                String gptResponses;
+                try {
+                    gptResponses = objectMapper.writeValueAsString(messages);
+                } catch (JsonProcessingException e) {
+                    log.error("GPT Message를 JSON으로 변환하는데 실패했습니다.", e);
+                    throw new RuntimeException(e);
+                }
+                prompt.getPromptGeneratorResult().updatePromptGeneratorContent(gptResponses);
+            }
+        });
+        return responses.size();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/admin/service/AdminService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryNoteAndPromptResponse;
 import tipitapi.drawmytoday.domain.diary.domain.Prompt;
+import tipitapi.drawmytoday.domain.diary.domain.PromptGeneratorResult;
 import tipitapi.drawmytoday.domain.diary.repository.PromptRepository;
 import tipitapi.drawmytoday.domain.diary.service.AdminDiaryService;
 import tipitapi.drawmytoday.domain.generator.api.gpt.domain.ChatCompletionsRole;
@@ -96,7 +97,8 @@ public class AdminService {
                     log.error("GPT Message를 JSON으로 변환하는데 실패했습니다.", e);
                     throw new RuntimeException(e);
                 }
-                prompt.getPromptGeneratorResult().updatePromptGeneratorContent(gptResponses);
+                PromptGeneratorResult result = PromptGeneratorResult.createGpt3Result(gptResponses);
+                prompt.updatePromptGeneratorResult(result);
             }
         });
         return responses.size();

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Prompt.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/Prompt.java
@@ -48,4 +48,8 @@ public class Prompt extends BaseEntity {
     public void imageGeneratorSuccess() {
         this.isSuccess = true;
     }
+
+    public void updatePromptGeneratorResult(PromptGeneratorResult promptGeneratorResult) {
+        this.promptGeneratorResult = promptGeneratorResult;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
@@ -39,8 +39,4 @@ public class PromptGeneratorResult {
     public String getPromptGeneratorContent() {
         return promptGeneratorContent;
     }
-
-    public void updatePromptGeneratorContent(String promptGeneratorContent) {
-        this.promptGeneratorContent = promptGeneratorContent;
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/domain/PromptGeneratorResult.java
@@ -39,4 +39,8 @@ public class PromptGeneratorResult {
     public String getPromptGeneratorContent() {
         return promptGeneratorContent;
     }
+
+    public void updatePromptGeneratorContent(String promptGeneratorContent) {
+        this.promptGeneratorContent = promptGeneratorContent;
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.domain.admin.dto.GetDiaryNoteAndPromptResponse;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
 
@@ -20,4 +21,6 @@ public interface DiaryQueryRepository {
 
     List<GetMonthlyDiariesResponse> getMonthlyDiaries(Long userId, LocalDateTime startMonth,
         LocalDateTime endMonth);
+
+    List<GetDiaryNoteAndPromptResponse> getDiaryNoteAndPrompt();
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -94,8 +94,8 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
         return queryFactory.select(
                 new QGetDiaryNoteAndPromptResponse(prompt.promptId, diary.notes, prompt.promptText))
             .from(prompt)
-            .leftJoin(image).on(prompt.promptId.eq(image.prompt.promptId))
-            .leftJoin(diary).on(image.diary.diaryId.eq(diary.diaryId))
+            .join(image).on(prompt.promptId.eq(image.prompt.promptId))
+            .join(diary).on(image.diary.diaryId.eq(diary.diaryId))
             .where(prompt.promptGeneratorResult.promptGeneratorContent.isNull())
             .where(prompt.promptText.notLike("%, portrait"))
             .limit(10L)

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/repository/DiaryQueryRepositoryImpl.java
@@ -18,7 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.support.PageableExecutionUtils;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.domain.admin.dto.GetDiaryNoteAndPromptResponse;
 import tipitapi.drawmytoday.domain.admin.dto.QGetDiaryAdminResponse;
+import tipitapi.drawmytoday.domain.admin.dto.QGetDiaryNoteAndPromptResponse;
 import tipitapi.drawmytoday.domain.diary.domain.Diary;
 import tipitapi.drawmytoday.domain.diary.dto.GetMonthlyDiariesResponse;
 import tipitapi.drawmytoday.domain.diary.dto.QGetMonthlyDiariesResponse;
@@ -84,6 +86,19 @@ public class DiaryQueryRepositoryImpl implements DiaryQueryRepository {
                 .and(diary.user.userId.eq(userId)))
             .orderBy(diary.diaryDate.asc())
             .groupBy(diary.diaryId)
+            .fetch();
+    }
+
+    @Override
+    public List<GetDiaryNoteAndPromptResponse> getDiaryNoteAndPrompt() {
+        return queryFactory.select(
+                new QGetDiaryNoteAndPromptResponse(prompt.promptId, diary.notes, prompt.promptText))
+            .from(prompt)
+            .leftJoin(image).on(prompt.promptId.eq(image.prompt.promptId))
+            .leftJoin(diary).on(image.diary.diaryId.eq(diary.diaryId))
+            .where(prompt.promptGeneratorResult.promptGeneratorContent.isNull())
+            .where(prompt.promptText.notLike("%, portrait"))
+            .limit(10L)
             .fetch();
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/AdminDiaryService.java
@@ -1,5 +1,7 @@
 package tipitapi.drawmytoday.domain.diary.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -7,7 +9,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tipitapi.drawmytoday.common.utils.Encryptor;
 import tipitapi.drawmytoday.domain.admin.dto.GetDiaryAdminResponse;
+import tipitapi.drawmytoday.domain.admin.dto.GetDiaryNoteAndPromptResponse;
 import tipitapi.drawmytoday.domain.diary.repository.DiaryRepository;
 import tipitapi.drawmytoday.domain.r2.service.R2PreSignedService;
 
@@ -18,6 +22,7 @@ public class AdminDiaryService {
 
     private final DiaryRepository diaryRepository;
     private final R2PreSignedService r2PreSignedService;
+    private final Encryptor encryptor;
     @Value("${presigned-image.expiration.admin-diaries}")
     private int imageExpiration;
 
@@ -32,5 +37,14 @@ public class AdminDiaryService {
         response.updateImageUrl(
             r2PreSignedService.getCustomDomainUrl(response.getImageURL()));
         return response;
+    }
+
+    public List<GetDiaryNoteAndPromptResponse> getDiaryNoteAndPrompt() {
+        return diaryRepository.getDiaryNoteAndPrompt()
+            .stream()
+            .map(response -> {
+                response.updateNotes(encryptor.decrypt(response.getNotes()));
+                return response;
+            }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/google/service/GoogleTranslatorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/google/service/GoogleTranslatorService.java
@@ -1,0 +1,44 @@
+package tipitapi.drawmytoday.domain.generator.api.google.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import tipitapi.drawmytoday.domain.generator.service.TranslateTextService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleTranslatorService implements TranslateTextService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper;
+    private static final String GOOGLE_TRANSLATE_URL = "https://translate.googleapis.com/translate_a/single";
+
+    @Override
+    public String translateAutoToEnglish(String text) {
+        String translatedText = null;
+        try {
+            String jsonResult = restTemplate.getForObject(
+                GOOGLE_TRANSLATE_URL + "?client=gtx&sl=auto&tl=en&dt=t&dt=bd&dj=1&source=icon&q="
+                    + text, String.class);
+            JsonNode rootNode = objectMapper.readTree(jsonResult);
+            if (rootNode.get("sentences") != null) {
+                translatedText = rootNode.get("sentences").get(0).get("trans").asText();
+            } else {
+                translatedText = rootNode.get("dict").get(0).get("terms").get(0).asText();
+            }
+        } catch (RestClientException e) {
+            log.error("구글 번역 API 요청 실패: {}", text, e);
+            throw e;
+        } catch (JsonProcessingException e) {
+            log.error("구글 번역 API 응답 파싱 실패: {}", text, e);
+            throw new RuntimeException("구글 번역 API 응답 파싱 실패: " + text, e);
+        }
+        return translatedText;
+    }
+}

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/TranslateTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/TranslateTextService.java
@@ -1,0 +1,6 @@
+package tipitapi.drawmytoday.domain.generator.service;
+
+public interface TranslateTextService {
+
+    String translateAutoToEnglish(String text);
+}


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- GPT Generator Content 추가 API[admin/add-gpt-generator-content] 생성
  - api 호출당 reputation(query param) x 10개의 gpt generator content가 생성되도록 구현
  - 한 reputation은 10개의 병렬 쓰레드로 google translator를 호출하고 결과를 db에 저장하며, 모든 쓰레드가 task를 수행하면  다음 reputation으로 넘어가도록 구현
  - 한 reputation 내 10개의 병렬 쓰레드가 모두 gpt generator content 만드는데 실패했다면, 종료
- 명시적 transaction 주입을 위한 TransactionTemplate 생성


## 관련 이슈

close #307 

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
