### PR TITLE
프롬프트 생성을 위해 호출하는 gpt response의 content 길이 150자 이하로 clamping한다

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptTextService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/service/PromptTextService.java
@@ -21,6 +21,7 @@ public class PromptTextService {
     private final String defaultStyle;
     private final TextGeneratorService gptService;
     private final ObjectMapper objectMapper;
+    private static final int GPT_PROMPT_MAX_LENGTH = 150;
 
     public PromptTextService(
         @Value("${kakao.karlo.generate_image.style.default}") String defaultStyle,
@@ -48,7 +49,8 @@ public class PromptTextService {
         String promptText;
         PromptGeneratorResult result = null;
         try {
-            List<? extends TextGeneratorContent> gptResult = gptService.generatePrompt(diaryNote);
+            List<? extends TextGeneratorContent> gptResult = gptService.generatePrompt(diaryNote,
+                GPT_PROMPT_MAX_LENGTH);
             String content = objectMapper.writeValueAsString(gptResult);
             promptText = gptResult.get(gptResult.size() - 1).getContent();
             result = PromptGeneratorResult.createGpt3Result(content);
@@ -72,7 +74,7 @@ public class PromptTextService {
         PromptGeneratorResult result = null;
         try {
             List<? extends TextGeneratorContent> gptResult = gptService.regeneratePrompt(
-                diaryNote, prompt);
+                diaryNote, prompt, GPT_PROMPT_MAX_LENGTH);
             String content = objectMapper.writeValueAsString(gptResult);
             promptText = gptResult.get(gptResult.size() - 1).getContent();
             result = PromptGeneratorResult.createGpt3Result(content);

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
@@ -16,9 +16,16 @@ public class Message implements TextGeneratorContent {
         this.content = content;
     }
 
-    public void clampContent() {
+    public void clampContent(int maxLength) {
+        substringContent(maxLength);
         if (content.lastIndexOf(".") != content.length() - 1) {
             content = content.substring(0, content.lastIndexOf(".") + 1);
+        }
+    }
+
+    private void substringContent(int maxLength) {
+        if (content.length() > maxLength) {
+            content = content.substring(0, maxLength);
         }
     }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
@@ -15,17 +15,4 @@ public class Message implements TextGeneratorContent {
         this.role = role;
         this.content = content;
     }
-
-    public void clampContent(int maxLength) {
-        substringContent(maxLength);
-        if (content.lastIndexOf(".") != content.length() - 1) {
-            content = content.substring(0, content.lastIndexOf(".") + 1);
-        }
-    }
-
-    private void substringContent(int maxLength) {
-        if (content.length() > maxLength) {
-            content = content.substring(0, maxLength);
-        }
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/service/GptService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/service/GptService.java
@@ -53,12 +53,12 @@ public class GptService implements TextGeneratorService {
         GptChatCompletionsRequest request = GptChatCompletionsRequest.createFirstMessage(
             gptChatCompletionsPrompt, diaryNote);
         HttpEntity<GptChatCompletionsRequest> httpEntity = createChatCompletionsRequest(request);
-        return requestGptChatCompletion(httpEntity, maxLength);
+        return requestGptChatCompletion(httpEntity);
     }
 
     @Override
     @Transactional(noRollbackFor = TextGeneratorException.class)
-    public List<Message> regeneratePrompt(String diaryNote, Prompt prompt, int maxLength) {
+    public List<Message> regeneratePrompt(String diaryNote, Prompt prompt) {
         Assert.hasText(diaryNote, "일기 내용이 없습니다.");
 
         String gptContent = prompt.getPromptGeneratorResult().getPromptGeneratorContent();
@@ -68,7 +68,7 @@ public class GptService implements TextGeneratorService {
             previousGptMessages, gptRegeneratePrompt);
         HttpEntity<GptChatCompletionsRequest> httpEntity = createChatCompletionsRequest(
             newGptChatCompletionsRequest);
-        return requestGptChatCompletion(httpEntity, maxLength);
+        return requestGptChatCompletion(httpEntity);
     }
 
     private List<Message> parsingGptContent(String gptContent) {
@@ -82,7 +82,7 @@ public class GptService implements TextGeneratorService {
     }
 
     private List<Message> requestGptChatCompletion(
-        HttpEntity<GptChatCompletionsRequest> httpEntity, int maxLength) {
+        HttpEntity<GptChatCompletionsRequest> httpEntity) {
         ResponseEntity<GptChatCompletionsResponse> responseEntity = null;
         try {
             responseEntity = openaiRestTemplate.postForEntity(
@@ -90,7 +90,6 @@ public class GptService implements TextGeneratorService {
 
             validIsSuccessfulRequest(responseEntity);
             Message responseMessage = responseEntity.getBody().getChoices()[0].getMessage();
-            responseMessage.clampContent(maxLength);
             List<Message> messages = httpEntity.getBody().getMessages();
             messages.add(responseMessage);
             return messages;

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
@@ -6,7 +6,8 @@ import tipitapi.drawmytoday.domain.generator.domain.TextGeneratorContent;
 
 public interface TextGeneratorService {
 
-    List<? extends TextGeneratorContent> generatePrompt(String keyword);
+    List<? extends TextGeneratorContent> generatePrompt(String keyword, int maxLength);
 
-    List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt);
+    List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt,
+        int maxLength);
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
@@ -8,6 +8,5 @@ public interface TextGeneratorService {
 
     List<? extends TextGeneratorContent> generatePrompt(String keyword, int maxLength);
 
-    List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt,
-        int maxLength);
+    List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt);
 }


### PR DESCRIPTION
# 구현 내용

## 구현 요약

- 프롬프트 생성을 위한 gpt api response로 프롬프트를 만들 때, 150글자 이하로 clamping
- gpt response는 clamping하지 않고 그대로 저장

## 관련 이슈

close #314

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
