### PR TITLE
Release 1.3.1

### DIFF
--- a/src/main/java/tipitapi/drawmytoday/domain/diary/dto/ReviewDiaryRequest.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/diary/dto/ReviewDiaryRequest.java
@@ -1,21 +1,31 @@
 package tipitapi.drawmytoday.domain.diary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Schema(description = "일기 리뷰 Request")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReviewDiaryRequest {
 
     @NotNull
-    @Min(value = 1, message = "review 값은 1~5 사이의 값이어야 합니다.")
-    @Max(value = 5, message = "review 값은 1~5 사이의 값이어야 합니다.")
     @Schema(description = "평가 점수 (1~5 사이의 숫자)")
     private String review;
+
+    public String getReview() {
+        try {
+            int review = Integer.parseInt(this.review);
+            if (review > 5) {
+                return "5";
+            } else if (review < 1) {
+                return "1";
+            } else {
+                return this.review;
+            }
+        } catch (NumberFormatException e) {
+            String errorMessage = String.format("평가 점수는 숫자여야 합니다. input: %s", this.review);
+            throw new IllegalArgumentException(errorMessage);
+        }
+    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/domain/Message.java
@@ -15,10 +15,4 @@ public class Message implements TextGeneratorContent {
         this.role = role;
         this.content = content;
     }
-
-    public void clampContent() {
-        if (content.lastIndexOf(".") != content.length() - 1) {
-            content = content.substring(0, content.lastIndexOf(".") + 1);
-        }
-    }
 }

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/service/GptService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/api/gpt/service/GptService.java
@@ -47,7 +47,7 @@ public class GptService implements TextGeneratorService {
 
     @Override
     @Transactional(noRollbackFor = TextGeneratorException.class)
-    public List<Message> generatePrompt(String diaryNote) {
+    public List<Message> generatePrompt(String diaryNote, int maxLength) {
         Assert.hasText(diaryNote, "일기 내용이 없습니다.");
 
         GptChatCompletionsRequest request = GptChatCompletionsRequest.createFirstMessage(
@@ -90,7 +90,6 @@ public class GptService implements TextGeneratorService {
 
             validIsSuccessfulRequest(responseEntity);
             Message responseMessage = responseEntity.getBody().getChoices()[0].getMessage();
-            responseMessage.clampContent();
             List<Message> messages = httpEntity.getBody().getMessages();
             messages.add(responseMessage);
             return messages;

--- a/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
+++ b/src/main/java/tipitapi/drawmytoday/domain/generator/service/TextGeneratorService.java
@@ -6,7 +6,7 @@ import tipitapi.drawmytoday.domain.generator.domain.TextGeneratorContent;
 
 public interface TextGeneratorService {
 
-    List<? extends TextGeneratorContent> generatePrompt(String keyword);
+    List<? extends TextGeneratorContent> generatePrompt(String keyword, int maxLength);
 
     List<? extends TextGeneratorContent> regeneratePrompt(String diaryNote, Prompt prompt);
 }


### PR DESCRIPTION
# 구현 내용

### #314 프롬프트 생성을 위해 호출하는 gpt response의 content 길이 150자 이하로 clamping 

- 프롬프트 생성을 위한 gpt api response로 프롬프트를 만들 때, 150글자 이하로 clamping
- gpt response는 clamping하지 않고 그대로 저장

### #315 이미지 평가시 review 값 clamping 작업

- review 값이 숫자가 아니거나 없으면 예외 반환
- 숫자 값이 1보다 작으면 1로 변환
- 숫자 값이 5보다 크면 5로 변환

## 관련 이슈

close #314
close #315

## 구현 내용

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
